### PR TITLE
Fix-001. As an admin, I'd like to have reports filter by user roles, currently they're view by anyone.

### DIFF
--- a/src/data/events/eventsReducer.ts
+++ b/src/data/events/eventsReducer.ts
@@ -64,7 +64,7 @@ export const eventsFetchAsync = (filter: any) => {
   return (dispatch: Dispatch<any>) => {
     search(
       remoteRoutes.events,
-      filter,
+      {filter},
       (resp: any) => {
         const getFullName = (name: any) => {
           return `${name.firstName} ${

--- a/src/modules/groups/Details.tsx
+++ b/src/modules/groups/Details.tsx
@@ -198,9 +198,7 @@ export default function Details() {
       name: "Reports",
       component: (
         <GroupEventsList
-          groupId={Number(groupId)}
-          groupName={data.name}
-          groupChildren={data.children ? data.children : []}
+          reports = {data.reports ? data.reports : []}
         />
       ),
     });

--- a/src/modules/groups/GroupEventsList.tsx
+++ b/src/modules/groups/GroupEventsList.tsx
@@ -11,18 +11,16 @@ import {
   makeStyles,
   Typography,
 } from "@material-ui/core";
-import React, { Fragment, useCallback, useEffect, useState } from "react";
+import React, { Fragment } from "react";
 import { IMobileRow } from "../../components/DataList";
 import PersonAvatar from "../../components/PersonAvatar";
 import { XHeadCell } from "../../components/table/XTableHead";
 import { printDate } from "../../utils/dateHelpers";
 import EventLink from "../events/EventLink";
-import { IEvent, IGroupEvent } from "../events/types";
-import Loading from "../../components/Loading";
+import { IEvent } from "../events/types";
 import XTable from "../../components/table/XTable";
 import { useHistory } from "react-router";
-import { localRoutes, remoteRoutes } from "../../data/constants";
-import { search } from "../../utils/ajax";
+import { localRoutes } from "../../data/constants";
 import { Alert } from "@material-ui/lab";
 
 const useStyles = makeStyles(() =>
@@ -34,9 +32,7 @@ const useStyles = makeStyles(() =>
 );
 
 interface IProps {
-  groupId: number;
-  groupName: string;
-  groupChildren: number[];
+  reports: any[];
 }
 
 const headCells: XHeadCell[] = [
@@ -64,45 +60,20 @@ const toMobileRow = (data: IEvent): IMobileRow => {
   };
 };
 
-const GroupEventsList = ({ groupId, groupChildren }: IProps) => {
+const GroupEventsList = ({ reports }: IProps) => {
   const classes = useStyles();
   const history = useHistory();
-  const [loading, setLoading] = useState<boolean>(false);
-  const [data, setData] = useState<IGroupEvent[]>([]);
 
   const handleItemClick = (id: string) => () => {
     history.push(`${localRoutes.events}/${id}`);
   };
-
-  const fetchGroupEvents = useCallback(() => {
-    setLoading(true);
-    search(
-      remoteRoutes.events,
-      {
-        groupIdList: groupChildren,
-      },
-      (resp) => {
-        setData(resp);
-      },
-      undefined,
-      () => {
-        setLoading(false);
-      }
-    );
-  }, [groupId]);
-
-  useEffect(() => {
-    fetchGroupEvents();
-  }, [fetchGroupEvents]);
-
-  if (loading) return <Loading />;
 
   return (
     <Grid container>
       <Box p={1} className={classes.root}>
         <Hidden smDown>
           <Box pt={1}>
-            {data.length === 0 ? (
+            {reports.length === 0 ? (
               <ListItem>
                 <Alert severity="info" style={{ width: "100%" }}>
                   No reports to display
@@ -111,7 +82,7 @@ const GroupEventsList = ({ groupId, groupChildren }: IProps) => {
             ) : (
               <XTable
                 headCells={headCells}
-                data={data}
+                data={reports}
                 initialRowsPerPage={10}
                 initialSortBy="name"
                 handleSelection={handleItemClick}
@@ -121,14 +92,14 @@ const GroupEventsList = ({ groupId, groupChildren }: IProps) => {
         </Hidden>
         <Hidden mdUp>
           <List>
-            {data.length === 0 ? (
+            {reports.length === 0 ? (
               <ListItem>
                 <Alert severity="info" style={{ width: "100%" }}>
                   No reports to display
                 </Alert>
               </ListItem>
             ) : (
-              data.map((row: any) => {
+              reports.map((row: any) => {
                 const mobileRow = toMobileRow(row);
                 return (
                   <Fragment key={row.id}>

--- a/src/modules/groups/types.ts
+++ b/src/modules/groups/types.ts
@@ -16,6 +16,7 @@ export interface IGroup {
   children: any[];
   totalAttendance?: number;
   percentageAttendance?: number;
+  reports?: any[];
 }
 
 export interface IGroupMembership {


### PR DESCRIPTION
**What does this PR do?**
- This PR adds a feature that allows users, with report viewing privileges, to see the reports of groups associated with the group they are a leader in.

**Description of tasks?**
- Logged in users will now have will now have a list of reports created by groups that they are linked to, i.e. descendants of the logged in user's group.

**Screenshot(s)**
![Screen Shot 2021-06-14 at 1 07 02 PM](https://user-images.githubusercontent.com/68650343/121875861-9998d400-cd11-11eb-89dd-d044b9d7539b.png)


