### PR TITLE
Fixed reports submission

### DIFF
--- a/src/components/inputs/XTextInput.tsx
+++ b/src/components/inputs/XTextInput.tsx
@@ -35,7 +35,7 @@ const XTextInput = ({
   const showError = Boolean(error && meta.touched);
   if (isHidden) {
     return <input type="hidden" name={field.name} value={field.value} onChange={field.onChange} />;
-  }  
+  }
   return (
     <TextField
       {...field}

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -138,7 +138,7 @@ export const remoteRoutes = {
 
   reports: `${apiBaseUrl}/api/reports`,
   reportsSubmit: `${apiBaseUrl}/api/reports/submit`,
-  reportsCategories: `${apiBaseUrl}api/reports/category`,
+  reportsCategories: `${apiBaseUrl}/api/reports/category`,
 
   contactsCompany: `${apiBaseUrl}/api/crm/contact/company`,
   contactsAvatar: `${apiBaseUrl}/api/crm/contact/avatar`,

--- a/src/modules/events/EventsFilter.tsx
+++ b/src/modules/events/EventsFilter.tsx
@@ -28,11 +28,13 @@ const initialData: any = {
   limit: 200,
   skip: 0,
 };
-const EventsFilter = ({ onFilter, showCategoriesFilter, showGroupsFilter, showParentGroupsFilter, parentGroupName }: IProps) => {
+const EventsFilter = ({
+  onFilter, showCategoriesFilter, showGroupsFilter, showParentGroupsFilter, parentGroupName,
+}: IProps) => {
   const { data, handleComboChange, handleDateChange } = useFilter({
     initialData,
     onFilter,
-    comboFields: ['categoryIdList', 'groupIdList','parentGroupIdList'],
+    comboFields: ['categoryIdList', 'groupIdList', 'parentGroupIdList'],
   });
   return (
     <form>
@@ -90,7 +92,7 @@ const EventsFilter = ({ onFilter, showCategoriesFilter, showGroupsFilter, showPa
         {showParentGroupsFilter && (
           <Grid item xs={12} md>
             <PRemoteSelect
-              remote={`${remoteRoutes.groupsCombo}?categories=${parentGroupName}`} 
+              remote={`${remoteRoutes.groupsCombo}?categories=${parentGroupName}`}
               name="parentGroupIdList"
               label={parentGroupName || 'Zone'}
               variant="outlined"

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -10,9 +10,7 @@ import XSelectInput from '../../components/inputs/XSelectInput';
 import XTextAreaInput from '../../components/inputs/XTextAreaInput';
 import { localRoutes, remoteRoutes } from '../../data/constants';
 import Toast from '../../utils/Toast';
-import {
-  ICreateReportSubmissionDto, IReportField,
-} from './types';
+import { ICreateReportSubmissionDto, IReportField } from './types';
 import { reportOptionToFieldOptions } from '../../components/inputs/inputHelpers';
 import { XRemoteSelect } from '../../components/inputs/XRemoteSelect';
 import { get, post } from '../../utils/ajax';
@@ -59,8 +57,8 @@ const ReportSubmissionForm = () => {
   const handleSmallGroupChange = (name: string, value: any) => {
     setFormData((prevFormData) => ({
       ...prevFormData,
-      [name]: value.name,
-      smallGroupId: value.id,
+      smallGroupName: value?.name,
+      smallGroupId: value?.id,
     }));
   };
 
@@ -71,13 +69,13 @@ const ReportSubmissionForm = () => {
     };
     // Validate required fields
     const requiredFields = reportFields.filter((field) => field.required);
-    const emptyFields = requiredFields.filter(
-      (field) => !values[field.name],
-    );
+    const emptyFields = requiredFields.filter((field) => !values[field.name]);
     if (emptyFields.length > 0) {
-      const emptyFieldLabels = emptyFields.map(field => field.label);
+      const emptyFieldLabels = emptyFields.map((field) => field.label);
       const labelsCommaSeparated = emptyFieldLabels.join(', ');
-      Toast.error(`Looks like some required fields are missing: ${labelsCommaSeparated}. Please complete these and try again.`);
+      Toast.error(
+        `Looks like some required fields are missing: ${labelsCommaSeparated}. Please complete these and try again.`,
+      );
       return;
     }
 
@@ -89,28 +87,39 @@ const ReportSubmissionForm = () => {
         history.push(localRoutes.reports);
       },
       () => {
-        Toast.error('Sorry, there was an error when submitting the report. Please retry.');
+        Toast.error(
+          'Sorry, there was an error when submitting the report. Please retry.',
+        );
       },
     );
-
   };
 
-  function getFieldComponent(field: IReportField, formData: any, handleChange: any) {
+  function getFieldComponent(
+    field: IReportField,
+    formData: any,
+    handleChange: any,
+  ) {
     const { name, label, type, hidden } = field;
     const value = formData[name] || '';
-    const options = field.options ? reportOptionToFieldOptions(field.options) : [];
+    const options = field.options
+      ? reportOptionToFieldOptions(field.options)
+      : [];
 
-    if (name == 'smallGroupId') {
-      return <XRemoteSelect
-        remote={remoteRoutes.groupsCombo}
-        filter={{ 'categories[]': 'Missional Community' }}
-        parser={({ name, id }: any) => ({ name, id })}
-        name={name}
-        label={label}
-        variant="outlined"
-        //customOnChange={(value: string) => handleSmallGroupChange(name, value)}
-        margin="none"
-      />;
+    if (name == 'smallGroupName') {
+      return (
+        <XRemoteSelect
+          remote={remoteRoutes.groupsCombo}
+          filter={{ 'categories[]': 'Missional Community' }}
+          parser={({ name, id }: any) => ({ name, id })}
+          name={name}
+          label={label}
+          variant="outlined"
+          customOnChange={(value: string) =>
+            handleSmallGroupChange(name, value)
+          }
+          margin="none"
+        />
+      );
     }
 
     switch (type) {
@@ -120,7 +129,8 @@ const ReportSubmissionForm = () => {
             id={name}
             name={name}
             value={value}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChange(name, e.target.value)
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              handleChange(name, e.target.value)
             }
             label={label}
             variant="outlined"
@@ -136,7 +146,9 @@ const ReportSubmissionForm = () => {
             id={name}
             name={name}
             value={value}
-            onChange={(value: MaterialUiPickersDate) => handleChange(name, value)}
+            onChange={(value: MaterialUiPickersDate) =>
+              handleChange(name, value)
+            }
             label={label}
             variant="outlined"
             margin="none"
@@ -147,7 +159,8 @@ const ReportSubmissionForm = () => {
         return (
           <XRadioInput
             name={name}
-            customOnChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChange(name, e.target.value)
+            customOnChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              handleChange(name, e.target.value)
             }
             label={label}
             options={options}
@@ -159,7 +172,8 @@ const ReportSubmissionForm = () => {
           <XSelectInput
             name={name}
             label={label}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChange(name, e.target.value)
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              handleChange(name, e.target.value)
             }
             options={options}
             required={field.required}
@@ -171,7 +185,8 @@ const ReportSubmissionForm = () => {
             id={name}
             name={name}
             value={value}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChange(name, e.target.value)
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              handleChange(name, e.target.value)
             }
             label={label}
             variant="outlined"
@@ -180,19 +195,20 @@ const ReportSubmissionForm = () => {
         );
       case 'number':
         return (
-            <XTextInput
-              id={name}
-              name={name}
-              required={false}
-              value={value}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChange(name, e.target.value)
-              }
-              label={label}
-              variant="outlined"
-              margin="none"
-              isHidden={hidden}
-              type= "number"
-            />
+          <XTextInput
+            id={name}
+            name={name}
+            required={false}
+            value={value}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              handleChange(name, e.target.value)
+            }
+            label={label}
+            variant="outlined"
+            margin="none"
+            isHidden={hidden}
+            type="number"
+          />
         );
       default:
         return null;
@@ -204,19 +220,19 @@ const ReportSubmissionForm = () => {
   }
 
   return (
-    <Layout title='Report Submission Form'>
+    <Layout title="Report Submission Form">
       <XForm
         onSubmit={handleSubmit}
         submitButtonAlignment="left"
         initialValues={formData}
       >
-          <Grid container spacing={2}>
-            {reportFields.map((field) => (
-              <Grid item xs={12} md={8} key={field.name}>
-                {getFieldComponent(field, formData, handleChange)}
-              </Grid>
-            ))}
-          </Grid>
+        <Grid container spacing={2}>
+          {reportFields.map((field) => (
+            <Grid item xs={12} md={8} key={field.name}>
+              {getFieldComponent(field, formData, handleChange)}
+            </Grid>
+          ))}
+        </Grid>
       </XForm>
     </Layout>
   );

--- a/src/theme/custom-colors.ts
+++ b/src/theme/custom-colors.ts
@@ -1,11 +1,7 @@
-import purple from '@material-ui/core/colors/cyan';
 import red from '@material-ui/core/colors/red';
 import green from '@material-ui/core/colors/green';
-import blueGrey from '@material-ui/core/colors';
 import amber from '@material-ui/core/colors/amber';
 import { colors } from '@material-ui/core';
-import { blue } from '@material-ui/core/colors';
-
 
 export const successColor = green[800];
 export const warningColor = amber[800];
@@ -13,7 +9,7 @@ export const errorColor = red[500];
 export const iconColor = colors.blueGrey[600];
 export const white = '#FFFFFF';
 export const black = '#000000';
-export const themeBackground =  white;
+export const themeBackground = white;
 
 export const warning = {
   contrastText: white,


### PR DESCRIPTION
# Ticket No
-

# Summary of changes
- The smallGroupId is now captured when the report is submitted, without being visible on the user's end.

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Try submitting the report, and check in the database, it should have `smallGroupName` and `smallGroupId`

# Out of scope
-  Assuming the smallGroupId is set to true, make it hidden, by executing this on the database.
```sql 
update worshipharvest.report_field
set hidden='t'
where id=3;```
