### PR TITLE
Fix: worked pagination, to start 20 rows

### DIFF
--- a/src/modules/reports/ReportSubmissionsList.tsx
+++ b/src/modules/reports/ReportSubmissionsList.tsx
@@ -112,7 +112,7 @@ const ReportSubmissions = () => {
               <XTable
                 headCells={data.columns || []}
                 data={data.data || []}
-                initialRowsPerPage={200}
+                initialRowsPerPage={20}
                 usePagination={true}
                 handleSelection={handleRowSelection}
                 initialSortBy="smallGroupName"


### PR DESCRIPTION
# Ticket No
- 

# Summary of changes
- While Checking submitted reports, the pagination is not visible. 

# How should this be tested? [Screenshots, Video or Type instructions]
- If a user scrolls to the bottom, they should see the pagination.
<img width="1653" height="607" alt="image" src="https://github.com/user-attachments/assets/316e6151-e4e7-44cb-b982-db53e66fa027" />


# Notes for reviewers
- None

# Out of scope
-  None
