### PR TITLE
fix: Reports viewing, submission and dropdown options works

### DIFF
--- a/src/components/table/XTable.tsx
+++ b/src/components/table/XTable.tsx
@@ -245,7 +245,7 @@ export default function XTable(props: XTableProps) {
         </div>
         {usePagination && (
           <TablePagination
-            rowsPerPageOptions={[5, 10, 25]}
+            rowsPerPageOptions={[10, 50, 100]}
             count={data.length}
             rowsPerPage={rowsPerPage}
             page={page}

--- a/src/modules/reports/ReportList.tsx
+++ b/src/modules/reports/ReportList.tsx
@@ -49,7 +49,7 @@ const ReportList: React.FC = () => {
       get(
         remoteRoutes.reports,
         (response: any) => {
-          setReports(response);
+          setReports(response.reports);
         },
         (error: any) => {
           Toast.error('Failed to fetch reports');
@@ -94,7 +94,7 @@ const ReportList: React.FC = () => {
               <ListItem key={report.id} alignItems="flex-start" disableGutters>
                 <ListItemText primary={report.name} />
                 <div className={classes.buttonContainer}>
-                  {report.fields && report.fields.length && (<Button
+                  {report.fieldCount && report.fieldCount > 0 &&  (<Button
                     variant="outlined"
                     color="primary"
                     onClick={() => handleSubmitReport(report)}>

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -11,7 +11,7 @@ import XTextAreaInput from '../../components/inputs/XTextAreaInput';
 import { localRoutes, remoteRoutes } from '../../data/constants';
 import Toast from '../../utils/Toast';
 import { ICreateReportSubmissionDto, IReportField } from './types';
-import { reportOptionToFieldOptions } from '../../components/inputs/inputHelpers';
+import { reportOptionToFieldOptions, toOptions } from '../../components/inputs/inputHelpers';
 import { XRemoteSelect } from '../../components/inputs/XRemoteSelect';
 import { get, post } from '../../utils/ajax';
 import Loading from '../../components/Loading';
@@ -80,7 +80,7 @@ const ReportSubmissionForm = () => {
     }
 
     post(
-      remoteRoutes.reportsSubmit,
+      `${remoteRoutes.reports}/${reportId}/submissions`,
       reportSubmissionData,
       () => {
         Toast.info('Report submitted successfully');
@@ -102,7 +102,7 @@ const ReportSubmissionForm = () => {
     const { name, label, type, hidden } = field;
     const value = formData[name] || '';
     const options = field.options
-      ? reportOptionToFieldOptions(field.options)
+      ? toOptions(field.options)
       : [];
 
     if (name == 'smallGroupName') {
@@ -173,7 +173,7 @@ const ReportSubmissionForm = () => {
             name={name}
             label={label}
             onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-              handleChange(name, e.target.value)
+              handleChange(name, e.target?.value)
             }
             options={options}
             required={field.required}

--- a/src/modules/reports/types.ts
+++ b/src/modules/reports/types.ts
@@ -4,10 +4,11 @@ export interface IReportColumn {
 }
 
 export interface IReportField {
+  id?: number,
   name: string,
   label: string,
   type: string,
-  options?: IReportFieldOption[],
+  options?:  string[],
   required?: boolean
   hidden?: boolean
 }
@@ -31,6 +32,7 @@ export interface IReport {
   data?: any[],
   footer?: string[],
   columns?: Array<IReportColumn> | []
+  fieldCount?:number
 }
 
 export interface ICreateReportSubmissionDto {


### PR DESCRIPTION
# Ticket No
- GoLive003

# Summary of changes
- I worked on the endpoints to match the new endpoints for submitting and viewing dropdowns

# How should this be tested? [Screenshots, Video or Type instructions]
- Check if reports are listed.
- Check if the submission button works

# Notes for reviewers
- 

# Out of scope
-  Viewing submitted reports


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Pagination: Available page-size options changed to 10, 50, and 100 rows.
  * Reports list: Data loading adjusted so report rows render consistently; the Submit button now enables based on reported field count.
  * Report submission form: Option lists generation improved for more reliable field choices.

* **Refactor**
  * Internal data typings updated to better represent report fields and counts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->