### PR TITLE
Fix/users

### DIFF
--- a/client-vite-new/src/App.tsx
+++ b/client-vite-new/src/App.tsx
@@ -10,6 +10,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 // Import actual components
 import Login from './modules/login/Login';
+import ForgotPassword from './modules/login/ForgotPassword';
 import SignUp from './modules/login/SignUp';
 import Dashboard from './modules/dashboard/Dashboard';
 import Contacts from './modules/contacts/Contacts';
@@ -34,7 +35,6 @@ import ManageNotifications from './modules/admin/notifications/ManageNotificatio
 import CheckInScreen from './modules/attendance/CheckInScreen';
 import ServiceSchedules from './modules/attendance/schedules/ServiceSchedules';
 import AttendanceHistory from './modules/attendance/history/AttendanceHistory';
-const ForgotPassword = () => <div>Forgot Password - Coming Soon</div>;
 const ResetPassword = () => <div>Reset Password - Coming Soon</div>;
 const UpdatePasswordConfirmation = () => <div>Update Password - Coming Soon</div>;
 const Splash = () => (

--- a/client-vite-new/src/modules/admin/users/UserManagement.tsx
+++ b/client-vite-new/src/modules/admin/users/UserManagement.tsx
@@ -23,6 +23,7 @@ import {
   CircularProgress,
   Switch,
   FormControlLabel,
+  TablePagination,
 } from '@mui/material';
 import {
   Add as AddIcon,
@@ -75,10 +76,16 @@ interface EditUserData {
   isActive: boolean;
 }
 
+const USER_FETCH_LIMIT = 100;
+
 const UserManagement = () => {
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
+  const [appliedSearch, setAppliedSearch] = useState('');
+  const [reloadKey, setReloadKey] = useState(0);
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(25);
   const [createDialog, setCreateDialog] = useState(false);
   const [editDialog, setEditDialog] = useState(false);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
@@ -101,8 +108,64 @@ const UserManagement = () => {
   });
 
   useEffect(() => {
+    let active = true;
+
+    const fetchUsers = async () => {
+      setLoading(true);
+
+      const collected: User[] = [];
+      let skip = 0;
+
+      try {
+        while (true) {
+          const batch = await new Promise<User[]>((resolve, reject) => {
+            search(
+              remoteRoutes.users,
+              {
+                query: appliedSearch || undefined,
+                limit: USER_FETCH_LIMIT,
+                skip,
+              },
+              (response) => resolve(Array.isArray(response) ? response : []),
+              reject,
+            );
+          });
+
+          collected.push(...batch);
+
+          if (batch.length < USER_FETCH_LIMIT) {
+            break;
+          }
+
+          skip += USER_FETCH_LIMIT;
+        }
+
+        if (!active) return;
+
+        setUsers(collected);
+      } catch (error) {
+        if (!active) return;
+        console.error('Users error:', error);
+        setUsers([]);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    };
+
     fetchUsers();
-  }, []);
+
+    return () => {
+      active = false;
+    };
+  }, [appliedSearch, reloadKey]);
+
+  useEffect(() => {
+    if (page > 0 && page * rowsPerPage >= users.length) {
+      setPage(Math.max(0, Math.ceil(users.length / rowsPerPage) - 1));
+    }
+  }, [users.length, page, rowsPerPage]);
 
   useEffect(() => {
     fetchAvailableRoles();
@@ -119,25 +182,6 @@ const UserManagement = () => {
 
     return () => window.clearTimeout(timeoutId);
   }, [contactQuery, createDialog]);
-
-  const fetchUsers = (search: string = '') => {
-    const url = search 
-      ? `${remoteRoutes.users}?query=${encodeURIComponent(search)}`
-      : remoteRoutes.users;
-    
-    get(
-      url,
-      (response) => {
-        console.log('Users response:', response);
-        setUsers(response || []);
-        setLoading(false);
-      },
-      (error) => {
-        console.error('Users error:', error);
-        setLoading(false);
-      }
-    );
-  };
 
   const fetchAvailableRoles = () => {
     get(
@@ -242,7 +286,7 @@ const UserManagement = () => {
       },
       () => {
         setCreateDialog(false);
-        fetchUsers();
+        setReloadKey((prev) => prev + 1);
         setSubmitting(false);
       },
       () => {
@@ -275,7 +319,7 @@ const UserManagement = () => {
       del(
         `${remoteRoutes.users}/${user.id}`,
         () => {
-          fetchUsers();
+          setReloadKey((prev) => prev + 1);
         },
         (error) => {
           console.error('Delete user error:', error);
@@ -304,7 +348,7 @@ const UserManagement = () => {
       updateData,
       () => {
         setEditDialog(false);
-        fetchUsers();
+        setReloadKey((prev) => prev + 1);
         setSubmitting(false);
       },
       (error) => {
@@ -314,7 +358,10 @@ const UserManagement = () => {
     );
   };
 
-  const filteredUsers = users;
+  const paginatedUsers = users.slice(
+    page * rowsPerPage,
+    page * rowsPerPage + rowsPerPage,
+  );
 
   const getInitials = (user: User) => {
     if (user.firstName && user.lastName) {
@@ -358,9 +405,13 @@ const UserManagement = () => {
           fullWidth
           placeholder="Search by username, email, first name, or last name..."
           value={searchTerm}
-          onChange={(e) => {
-            setSearchTerm(e.target.value);
-            fetchUsers(e.target.value);
+          onChange={(e) => setSearchTerm(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              setAppliedSearch(searchTerm.trim());
+              setPage(0);
+            }
           }}
           variant="outlined"
           size="small"
@@ -368,6 +419,15 @@ const UserManagement = () => {
             startAdornment: <SearchIcon sx={{ mr: 1, color: 'text.secondary' }} />,
           }}
         />
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setAppliedSearch(searchTerm.trim());
+            setPage(0);
+          }}
+        >
+          Search
+        </Button>
       </Box>
 
       {/* Users Table */}
@@ -376,7 +436,7 @@ const UserManagement = () => {
           <TableHead>
             <TableRow>
               <TableCell>User</TableCell>
-              <TableCell>Email</TableCell>
+              {/* <TableCell>Email</TableCell> */}
               <TableCell>Roles</TableCell>
               <TableCell>Status</TableCell>
               <TableCell>Last Login</TableCell>
@@ -384,7 +444,7 @@ const UserManagement = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {filteredUsers.map((user) => (
+            {paginatedUsers.map((user) => (
               <TableRow key={user.id}>
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={2}>
@@ -407,7 +467,7 @@ const UserManagement = () => {
                     </Box>
                   </Box>
                 </TableCell>
-                <TableCell>{user.email}</TableCell>
+                {/* <TableCell>{user.email}</TableCell> */}
                 <TableCell>
                   <Box display="flex" gap={0.5} flexWrap="wrap">
                     {user.roles.slice(0, 3).map((role) => (
@@ -441,8 +501,22 @@ const UserManagement = () => {
           </TableBody>
         </Table>
       </TableContainer>
+      <Box display="flex" justifyContent="flex-end" mt={1}>
+        <TablePagination
+          component="div"
+          count={users.length}
+          page={page}
+          onPageChange={(_, newPage) => setPage(newPage)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={(e) => {
+            setRowsPerPage(parseInt(e.target.value, 10));
+            setPage(0);
+          }}
+          rowsPerPageOptions={[10, 25, 50, 100]}
+        />
+      </Box>
 
-      {filteredUsers.length === 0 && (
+      {users.length === 0 && (
         <Box textAlign="center" py={4}>
           <Typography color="text.secondary">
             No users found matching your search.

--- a/client-vite-new/src/modules/admin/users/UserManagement.tsx
+++ b/client-vite-new/src/modules/admin/users/UserManagement.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   TextField,
+  Autocomplete,
   Table,
   TableBody,
   TableCell,
@@ -19,6 +20,7 @@ import {
   DialogActions,
   Chip,
   Avatar,
+  CircularProgress,
   Switch,
   FormControlLabel,
 } from '@mui/material';
@@ -28,7 +30,7 @@ import {
   Delete as DeleteIcon,
   Search as SearchIcon,
 } from '@mui/icons-material';
-import { get, post, patch, del } from '../../../utils/ajax';
+import { get, post, patch, del, search } from '../../../utils/ajax';
 import { remoteRoutes } from '../../../data/constants';
 
 interface User {
@@ -43,36 +45,35 @@ interface User {
   createdAt: string;
   avatar?: string;
   fullName?: string;
+  contactId: number;
+}
+
+interface ContactOption {
+  id: number;
+  name: string;
+  avatar?: string | null;
+}
+
+interface RoleDto {
+  id: number;
+  role: string;
+  description: string;
+  permissions: string[];
+  isActive: boolean;
 }
 
 interface CreateUserData {
-  username: string;
-  email: string;
+  contact: ContactOption | null;
   password: string;
-  firstName?: string;
-  lastName?: string;
   roles: string[];
-  isActive?: boolean;
+  isActive: boolean;
 }
 
-const availableRoles = [
-  'DASHBOARD',
-  'CRM_VIEW',
-  'CRM_EDIT',
-  'USER_VIEW',
-  'USER_EDIT',
-  'ROLE_EDIT',
-  'TAG_VIEW',
-  'TAG_EDIT',
-  'GROUP_VIEW',
-  'GROUP_EDIT',
-  'MC_VIEW',
-  'EVENT_VIEW',
-  'EVENT_EDIT',
-  'REPORT_VIEW',
-  'REPORT_VIEW_SUBMISSIONS',
-  'MANAGE_HELP',
-];
+interface EditUserData {
+  password: string;
+  roles: string[];
+  isActive: boolean;
+}
 
 const UserManagement = () => {
   const [users, setUsers] = useState<User[]>([]);
@@ -83,12 +84,18 @@ const UserManagement = () => {
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [isActiveStatus, setIsActiveStatus] = useState(true);
-  const [formData, setFormData] = useState<CreateUserData>({
-    username: '',
-    email: '',
+  const [availableRoles, setAvailableRoles] = useState<string[]>([]);
+  const [contactOptions, setContactOptions] = useState<ContactOption[]>([]);
+  const [loadingContacts, setLoadingContacts] = useState(false);
+  const [contactQuery, setContactQuery] = useState('');
+  const [createFormData, setCreateFormData] = useState<CreateUserData>({
+    contact: null,
     password: '',
-    firstName: '',
-    lastName: '',
+    roles: [],
+    isActive: true,
+  });
+  const [editFormData, setEditFormData] = useState<EditUserData>({
+    password: '',
     roles: [],
     isActive: true,
   });
@@ -96,6 +103,22 @@ const UserManagement = () => {
   useEffect(() => {
     fetchUsers();
   }, []);
+
+  useEffect(() => {
+    fetchAvailableRoles();
+  }, []);
+
+  useEffect(() => {
+    if (!createDialog) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      fetchCreateContacts(contactQuery);
+    }, 250);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [contactQuery, createDialog]);
 
   const fetchUsers = (search: string = '') => {
     const url = search 
@@ -116,31 +139,135 @@ const UserManagement = () => {
     );
   };
 
+  const fetchAvailableRoles = () => {
+    get(
+      remoteRoutes.roles,
+      (response: RoleDto[] = []) => {
+        const activeRoles = response
+          .filter((role) => role.isActive)
+          .map((role) => role.role);
+        setAvailableRoles(activeRoles);
+      },
+      () => {
+        setAvailableRoles([]);
+      }
+    );
+  };
+
+  const fetchCreateContacts = (query: string = '') => {
+    setLoadingContacts(true);
+    search(
+      remoteRoutes.contactsPeopleCombo,
+      {
+        skipUsers: true,
+        query,
+        limit: 300,
+      },
+      (response: ContactOption[] = []) => {
+        setContactOptions(Array.isArray(response) ? response : []);
+        setLoadingContacts(false);
+      },
+      () => {
+        setContactOptions([]);
+        setLoadingContacts(false);
+      }
+    );
+  };
+
   const handleCreateUser = () => {
-    setFormData({
-      username: '',
-      email: '',
+    setCreateFormData({
+      contact: null,
       password: '',
-      firstName: '',
-      lastName: '',
       roles: [],
+      isActive: true,
     });
+    setContactQuery('');
+    fetchCreateContacts('');
+    if (!availableRoles.length) {
+      fetchAvailableRoles();
+    }
     setCreateDialog(true);
+  };
+
+  const handleCloseCreateDialog = () => {
+    setCreateDialog(false);
+    setSubmitting(false);
+  };
+
+  const handleCreateFormChange = <K extends keyof CreateUserData>(
+    field: K,
+    value: CreateUserData[K],
+  ) => {
+    setCreateFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleEditFormChange = <K extends keyof EditUserData>(
+    field: K,
+    value: EditUserData[K],
+  ) => {
+    setEditFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const toggleCreateRole = (role: string) => {
+    const currentRoles = createFormData.roles;
+    const newRoles = currentRoles.includes(role)
+      ? currentRoles.filter((existingRole) => existingRole !== role)
+      : [...currentRoles, role];
+    handleCreateFormChange('roles', newRoles);
+  };
+
+  const toggleEditRole = (role: string) => {
+    const currentRoles = editFormData.roles;
+    const newRoles = currentRoles.includes(role)
+      ? currentRoles.filter((existingRole) => existingRole !== role)
+      : [...currentRoles, role];
+    handleEditFormChange('roles', newRoles);
+  };
+
+  const getContactOptionLabel = (option: ContactOption) => option?.name ?? '';
+
+  const handleSubmitCreate = () => {
+    if (!createFormData.contact) {
+      return;
+    }
+
+    setSubmitting(true);
+    post(
+      remoteRoutes.users,
+      {
+        contactId: createFormData.contact.id,
+        password: createFormData.password,
+        roles: createFormData.roles,
+        isActive: createFormData.isActive,
+      },
+      () => {
+        setCreateDialog(false);
+        fetchUsers();
+        setSubmitting(false);
+      },
+      () => {
+        setSubmitting(false);
+      }
+    );
   };
 
   const handleEditUser = (user: User) => {
     setSelectedUser(user);
     setIsActiveStatus(user.isActive);
-    setFormData({
-      username: user.username,
-      email: user.email,
-      password: '', // Don't pre-fill password
-      firstName: user.firstName || '',
-      lastName: user.lastName || '',
+    setEditFormData({
+      password: '',
       roles: user.roles,
       isActive: user.isActive,
     });
+    if (!availableRoles.length) {
+      fetchAvailableRoles();
+    }
     setEditDialog(true);
+  };
+
+  const handleCloseEditDialog = () => {
+    setEditDialog(false);
+    setSubmitting(false);
   };
 
   const handleDeleteUser = (user: User) => {
@@ -157,39 +284,19 @@ const UserManagement = () => {
     }
   };
 
-  const handleSubmitCreate = () => {
-    setSubmitting(true);
-    post(
-      remoteRoutes.users,
-      formData,
-      () => {
-        setCreateDialog(false);
-        fetchUsers();
-        setSubmitting(false);
-      },
-      (error) => {
-        console.error('Create user error:', error);
-        setSubmitting(false);
-      }
-    );
-  };
-
   const handleSubmitEdit = () => {
     if (!selectedUser) return;
 
     setSubmitting(true);
 
-    // Backend expects: id, username, roles, isActive (password is optional)
     const updateData: any = {
       id: selectedUser.id,
-      username: formData.username,
-      // roles: formData.roles,
+      roles: editFormData.roles,
       isActive: isActiveStatus,
     };
 
-    // Include password if provided
-    if (formData.password) {
-      updateData.password = formData.password;
+    if (editFormData.password) {
+      updateData.password = editFormData.password;
     }
 
     patch(
@@ -205,18 +312,6 @@ const UserManagement = () => {
         setSubmitting(false);
       }
     );
-  };
-
-  const handleFormChange = (field: keyof CreateUserData, value: any) => {
-    setFormData(prev => ({ ...prev, [field]: value }));
-  };
-
-  const handleRoleToggle = (role: string) => {
-    const currentRoles = formData.roles;
-    const newRoles = currentRoles.includes(role)
-      ? currentRoles.filter(r => r !== role)
-      : [...currentRoles, role];
-    handleFormChange('roles', newRoles);
   };
 
   const filteredUsers = users;
@@ -293,7 +388,7 @@ const UserManagement = () => {
               <TableRow key={user.id}>
                 <TableCell>
                   <Box display="flex" alignItems="center" gap={2}>
-                    <Avatar 
+                    <Avatar
                       src={user.avatar || undefined}
                       sx={{ bgcolor: 'primary.main' }}
                     >
@@ -301,7 +396,7 @@ const UserManagement = () => {
                     </Avatar>
                     <Box>
                       <Typography variant="subtitle2">
-                        {user.firstName && user.lastName 
+                        {user.firstName && user.lastName
                           ? `${user.fullName}`
                           : user.fullName
                         }
@@ -356,64 +451,89 @@ const UserManagement = () => {
       )}
 
       {/* Create User Dialog */}
-      <Dialog open={createDialog} onClose={() => setCreateDialog(false)} maxWidth="sm" fullWidth>
+      <Dialog open={createDialog} onClose={handleCloseCreateDialog} maxWidth="sm" fullWidth>
         <DialogTitle>Create New User</DialogTitle>
         <DialogContent>
           <Box pt={1} display="flex" flexDirection="column" gap={2}>
-            <TextField
-              label="Username"
-              required
-              value={formData.username}
-              onChange={(e) => handleFormChange('username', e.target.value)}
-            />
-            <TextField
-              label="Email"
-              type="email"
-              required
-              value={formData.email}
-              onChange={(e) => handleFormChange('email', e.target.value)}
+            <Autocomplete
+              options={contactOptions}
+              value={createFormData.contact}
+              loading={loadingContacts}
+              onChange={(_, value) => handleCreateFormChange('contact', value)}
+              onInputChange={(_, value, reason) => {
+                if (reason === 'input') {
+                  setContactQuery(value);
+                }
+              }}
+              getOptionLabel={getContactOptionLabel}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+              noOptionsText={contactQuery ? 'No matching people found' : 'No people available'}
+              renderInput={(params) => (
+                <TextField
+                  {...params}
+                  label="Person"
+                  required
+                  helperText="Only contacts without existing user accounts are listed"
+                  InputProps={{
+                    ...params.InputProps,
+                    endAdornment: (
+                      <>
+                        {loadingContacts ? <CircularProgress color="inherit" size={20} /> : null}
+                        {params.InputProps.endAdornment}
+                      </>
+                    ),
+                  }}
+                />
+              )}
             />
             <TextField
               label="Password"
-              type="password"
+              type="text"
               required
-              value={formData.password}
-              onChange={(e) => handleFormChange('password', e.target.value)}
+              value={createFormData.password}
+              onChange={(e) => handleCreateFormChange('password', e.target.value)}
+              helperText="Must be at least 8 characters"
             />
-            <Box display="flex" gap={2}>
-              <TextField
-                label="First Name"
-                value={formData.firstName}
-                onChange={(e) => handleFormChange('firstName', e.target.value)}
-              />
-              <TextField
-                label="Last Name"
-                value={formData.lastName}
-                onChange={(e) => handleFormChange('lastName', e.target.value)}
-              />
-            </Box>
-            
+            <FormControlLabel
+              label={createFormData.isActive ? 'Active' : 'Inactive'}
+              control={
+                <Switch
+                  color={createFormData.isActive ? 'success' : 'default'}
+                  checked={createFormData.isActive}
+                  onChange={(e) => handleCreateFormChange('isActive', e.target.checked)}
+                />
+              }
+            />
             <Typography variant="subtitle2" sx={{ mt: 2 }}>Roles:</Typography>
             <Box display="flex" flexWrap="wrap" gap={1}>
               {availableRoles.map((role) => (
                 <Chip
                   key={role}
                   label={role}
-                  onClick={() => handleRoleToggle(role)}
-                  color={formData.roles.includes(role) ? 'primary' : 'default'}
-                  variant={formData.roles.includes(role) ? 'filled' : 'outlined'}
+                  onClick={() => toggleCreateRole(role)}
+                  color={createFormData.roles.includes(role) ? 'primary' : 'default'}
+                  variant={createFormData.roles.includes(role) ? 'filled' : 'outlined'}
                   size="small"
                 />
               ))}
             </Box>
+
+            <Typography variant="subtitle2" sx={{ mt: 1 }}>
+              Password will be sent exactly as shown
+            </Typography>
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setCreateDialog(false)}>Cancel</Button>
-          <Button 
-            variant="contained" 
+          <Button onClick={handleCloseCreateDialog}>Cancel</Button>
+          <Button
+            variant="contained"
             onClick={handleSubmitCreate}
-            disabled={submitting || !formData.username || !formData.email || !formData.password}
+            disabled={
+              submitting
+              || !createFormData.contact
+              || createFormData.password.length < 8
+              || createFormData.roles.length === 0
+            }
           >
             {submitting ? 'Creating...' : 'Create User'}
           </Button>
@@ -421,31 +541,16 @@ const UserManagement = () => {
       </Dialog>
 
       {/* Edit User Dialog */}
-      <Dialog open={editDialog} onClose={() => setEditDialog(false)} maxWidth="sm" fullWidth>
+      <Dialog open={editDialog} onClose={handleCloseEditDialog} maxWidth="sm" fullWidth>
         <DialogTitle>Edit User: {selectedUser?.username}</DialogTitle>
         <DialogContent>
           <Box pt={1} display="flex" flexDirection="column" gap={2}>
             <TextField
-              label="Username"
-              required
-              value={formData.username}
-              onChange={(e) => handleFormChange('username', e.target.value)}
-            />
-            <TextField
               label="Password"
               type="password"
-              value={formData.password}
-              onChange={(e) => handleFormChange('password', e.target.value)}
+              value={editFormData.password}
+              onChange={(e) => handleEditFormChange('password', e.target.value)}
               helperText="Leave blank to keep current password"
-            />
-            <TextField
-              label="Email"
-              type="email"
-              required
-              value={formData.email}
-              onChange={(e) => handleFormChange('email', e.target.value)}
-              disabled
-              helperText="Email cannot be changed"
             />
             <FormControlLabel
               label={isActiveStatus ? 'Active' : 'Inactive'}
@@ -457,22 +562,6 @@ const UserManagement = () => {
                 />
               }
             />
-            <Box display="flex" gap={2}>
-              <TextField
-                label="First Name"
-                value={formData.firstName}
-                onChange={(e) => handleFormChange('firstName', e.target.value)}
-                disabled
-                helperText="Read-only"
-              />
-              <TextField
-                label="Last Name"
-                value={formData.lastName}
-                onChange={(e) => handleFormChange('lastName', e.target.value)}
-                disabled
-                helperText="Read-only"
-              />
-            </Box>
 
             <Typography variant="subtitle2" sx={{ mt: 2 }}>Roles:</Typography>
             <Box display="flex" flexWrap="wrap" gap={1}>
@@ -480,9 +569,9 @@ const UserManagement = () => {
                 <Chip
                   key={role}
                   label={role}
-                  onClick={() => handleRoleToggle(role)}
-                  color={formData.roles.includes(role) ? 'primary' : 'default'}
-                  variant={formData.roles.includes(role) ? 'filled' : 'outlined'}
+                  onClick={() => toggleEditRole(role)}
+                  color={editFormData.roles.includes(role) ? 'primary' : 'default'}
+                  variant={editFormData.roles.includes(role) ? 'filled' : 'outlined'}
                   size="small"
                 />
               ))}
@@ -490,11 +579,11 @@ const UserManagement = () => {
           </Box>
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setEditDialog(false)}>Cancel</Button>
+          <Button onClick={handleCloseEditDialog}>Cancel</Button>
           <Button
             variant="contained"
             onClick={handleSubmitEdit}
-            disabled={submitting || !formData.username}
+            disabled={submitting}
           >
             {submitting ? 'Updating...' : 'Save Changes'}
           </Button>

--- a/client-vite-new/src/modules/contacts/Contacts.tsx
+++ b/client-vite-new/src/modules/contacts/Contacts.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Container,
   Typography,
@@ -51,81 +51,107 @@ interface Contact {
 }
 
 interface ContactFilter {
-  search?: string;
   limit?: number;
-  offset?: number;
+  skip?: number;
 }
+
+const CONTACT_FETCH_LIMIT = 100;
 
 const Contacts = () => {
   const navigate = useNavigate();
 
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [loading, setLoading] = useState(true);
-
-  // Visible input text that should NOT trigger reload while typing
   const [searchInput, setSearchInput] = useState('');
-
-  // The applied search term used in requests; set only when user submits search
   const [appliedSearch, setAppliedSearch] = useState<string>('');
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(25);
 
   const [createDialog, setCreateDialog] = useState(false);
   const [uploadDialog, setUploadDialog] = useState(false);
-
-  // Pagination-aware filter: limit + offset; search applied via appliedSearch
   const [filter, setFilter] = useState<ContactFilter>({
-    limit: 50,
-    offset: 0,
-    search: '',
+    limit: CONTACT_FETCH_LIMIT,
+    skip: 0,
   });
-
-  // Optional total count if API returns it
   const [total, setTotal] = useState<number>(0);
-
-  // Actions menu state
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedContact, setSelectedContact] = useState<Contact | null>(null);
-
-  // Derive pagination UI state from filter
-  const rowsPerPage = filter.limit || 25;
-  const page = Math.floor((filter.offset || 0) / rowsPerPage);
-
-  // Build query params memoized to avoid unnecessary reloads
-  const queryParams = useMemo(
-    () => ({
-      ...filter,
-      email: appliedSearch || undefined, 
-    }),
-    [filter, appliedSearch]
+  const paginatedContacts = contacts.slice(
+    page * rowsPerPage,
+    page * rowsPerPage + rowsPerPage,
   );
 
   useEffect(() => {
-    setLoading(true);
-    search(
-      remoteRoutes.contacts,
-      queryParams,
-      (response) => {
-        // Support both array and { data, total } shapes
-        const data: Contact[] = Array.isArray(response) ? response : response?.data ?? [];
-        const totalCount =
-          (Array.isArray(response) ? response.length : response?.total) ?? data.length;
+    let active = true;
 
-        setContacts(data || []);
-        setTotal(totalCount);
-        setLoading(false);
-      },
-      (error) => {
+    const loadAllContacts = async () => {
+      setLoading(true);
+
+      const collected: Contact[] = [];
+      let skip = 0;
+
+      try {
+        while (true) {
+          const batch = await new Promise<Contact[]>((resolve, reject) => {
+            search(
+              remoteRoutes.contacts,
+              {
+                ...filter,
+                skip,
+                query: appliedSearch || undefined,
+              },
+              (response) => {
+                const data: Contact[] = Array.isArray(response)
+                  ? response
+                  : response?.data ?? [];
+                resolve(data);
+              },
+              reject,
+            );
+          });
+
+          collected.push(...batch);
+
+          if (batch.length < CONTACT_FETCH_LIMIT) {
+            break;
+          }
+
+          skip += CONTACT_FETCH_LIMIT;
+        }
+
+        if (!active) return;
+
+        setContacts(collected);
+        setTotal(collected.length);
+      } catch (error) {
+        if (!active) return;
         console.error('Contacts error:', error);
-        setLoading(false);
+        setContacts([]);
+        setTotal(0);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
       }
-    );
-  }, [queryParams]);
+    };
 
-  // Trigger search only when the user clicks the button or presses Enter.
-  const handleSearch = useCallback(() => {
+    loadAllContacts();
+
+    return () => {
+      active = false;
+    };
+  }, [appliedSearch, filter]);
+
+  useEffect(() => {
+    if (page > 0 && page * rowsPerPage >= contacts.length) {
+      setPage(Math.max(0, Math.ceil(contacts.length / rowsPerPage) - 1));
+    }
+  }, [contacts.length, page, rowsPerPage]);
+
+  const handleSearch = () => {
     setAppliedSearch(searchInput.trim());
-    // Reset to first page on new search
-    setFilter((prev) => ({ ...prev, offset: 0 }));
-  }, [searchInput]);
+    setPage(0);
+  };
 
   const handleSearchKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
@@ -248,7 +274,7 @@ const Contacts = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {contacts.map((contact, idx) => (
+                {paginatedContacts.map((contact, idx) => (
                   <TableRow
                     key={contact.id}
                     hover
@@ -320,17 +346,14 @@ const Contacts = () => {
             <Box display="flex" justifyContent="flex-end" mt={1}>
               <TablePagination
                 component="div"
-                count={total || contacts.length}
+                count={total}
                 page={page}
-                onPageChange={(_, newPage) => {
-                  const newOffset = newPage * rowsPerPage;
-                  setFilter((prev) => ({ ...prev, offset: newOffset }));
-                }}
+                onPageChange={(_, newPage) => setPage(newPage)}
                 rowsPerPage={rowsPerPage}
                 onRowsPerPageChange={(e) => {
                   const newLimit = parseInt(e.target.value, 10);
-                  // Reset to first page when page size changes
-                  setFilter((prev) => ({ ...prev, limit: newLimit }));
+                  setRowsPerPage(newLimit);
+                  setPage(0);
                 }}
                 rowsPerPageOptions={[10, 25, 50, 100]}
               />

--- a/client-vite-new/src/modules/login/ForgotPassword.tsx
+++ b/client-vite-new/src/modules/login/ForgotPassword.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react';
+import {
+  TextField,
+  Button,
+  Typography,
+  Box,
+  Alert,
+  Link,
+  CircularProgress,
+} from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { post } from '../../utils/ajax';
+import { localRoutes, remoteRoutes } from '../../data/constants';
+import loginBackground from '../../assets/images/login-background.jpg';
+
+const ForgotPassword = () => {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    setSuccess('');
+
+    post(
+      remoteRoutes.forgotPassword,
+      {
+        churchName: 'Worship Harvest',
+        username: email,
+      },
+      () => {
+        setSuccess(
+          'An email has been sent to the provided address if it exists in the platform.',
+        );
+        setEmail('');
+        setLoading(false);
+      },
+      () => {
+        setError(
+          'Sorry, we encountered an issue while processing your password reset request. Please try again.',
+        );
+        setLoading(false);
+      },
+    );
+  };
+
+  return (
+    <Box sx={{ display: 'flex', minHeight: '100vh' }}>
+      <Box
+        sx={{
+          flex: 1,
+          display: { xs: 'none', md: 'flex' },
+          backgroundImage: `url(${loginBackground})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            backgroundColor: 'rgba(0, 0, 0, 0.3)',
+          }}
+        />
+        <Box sx={{ textAlign: 'center', color: 'white', zIndex: 1, px: 4, margin: 'auto' }}>
+          <Typography variant="h3" fontWeight="bold" gutterBottom>
+            Project Zoe
+          </Typography>
+          <Typography variant="h6" sx={{ opacity: 0.9 }}>
+            Password Recovery
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          p: { xs: 3, sm: 6 },
+          backgroundColor: '#fff',
+        }}
+      >
+        <Box sx={{ width: '100%', maxWidth: 400 }}>
+          <Typography variant="h4" fontWeight="bold" gutterBottom>
+            Forgot Password
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 4 }}>
+            Enter your email address and we&apos;ll send reset instructions if an account exists.
+          </Typography>
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
+
+          {success && (
+            <Alert severity="success" sx={{ mb: 2 }}>
+              {success}
+            </Alert>
+          )}
+
+          <Box component="form" onSubmit={handleSubmit}>
+            <TextField
+              fullWidth
+              label="Email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              autoFocus
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              sx={{ mb: 3 }}
+            />
+
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              disabled={loading}
+              sx={{
+                py: 1.5,
+                backgroundColor: '#1a2332',
+                '&:hover': { backgroundColor: '#2d4059' },
+                textTransform: 'none',
+                fontSize: '1rem',
+                mb: 2,
+              }}
+            >
+              {loading ? <CircularProgress size={24} color="inherit" /> : 'Send Reset Email'}
+            </Button>
+
+            <Typography variant="body2" align="center" color="text.secondary">
+              Remembered your password?{' '}
+              <Link
+                component="button"
+                type="button"
+                variant="body2"
+                onClick={() => navigate(localRoutes.login)}
+                sx={{ cursor: 'pointer' }}
+              >
+                Back to login
+              </Link>
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default ForgotPassword;

--- a/client-vite-new/src/modules/login/Login.tsx
+++ b/client-vite-new/src/modules/login/Login.tsx
@@ -7,7 +7,10 @@ import {
   Alert,
   Link,
   CircularProgress,
+  IconButton,
+  InputAdornment,
 } from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { login } from '../../data/coreSlice';
@@ -25,6 +28,7 @@ const Login = () => {
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({
@@ -139,12 +143,36 @@ const Login = () => {
               fullWidth
               label="Password"
               name="password"
-              type="password"
+              type={showPassword ? 'text' : 'password'}
               autoComplete="current-password"
               value={formData.password}
               onChange={handleChange}
-              sx={{ mb: 3 }}
+              sx={{ mb: 2 }}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      edge="end"
+                      onClick={() => setShowPassword((value) => !value)}
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    >
+                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
             />
+            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 3 }}>
+              <Link
+                component="button"
+                type="button"
+                variant="body2"
+                onClick={() => navigate(localRoutes.forgotPassword)}
+                sx={{ cursor: 'pointer' }}
+              >
+                Forgot Password?
+              </Link>
+            </Box>
             <Button
               type="submit"
               fullWidth


### PR DESCRIPTION
# Ticket No
- FIX_USERS_01

# Summary of changes
- add password visibility toggle to the Vite login form
- add forgot-password link and new forgot-password page wired to /api/auth/forgot-password
- replace placeholder forgot-password route with a working Vite screen
- simplify Vite user create/edit flows to match current product direction
- restore role selection in create-user and include roles in the create payload
- keep edit-user limited to roles, password, and active status
- remove username derivation/manual username handling from Vite user management
- add working pagination to the Vite users table so all matching records are reachable
- fix contacts pagination to use backend-compatible skip/limit semantics
- fetch all paged user/contact records from the backend and paginate locally in the UI
- preserve search behaviour while ensuring NO users or contacts are missed across pages

# How should this be tested? [Screenshots, Video or Type instructions]
- See screenshots, and make sure the backend update has been applied.

## Login Page before 
<img width="1479" height="859" alt="image" src="https://github.com/user-attachments/assets/c78bf418-41a0-43de-8e83-170f55e8a04d" />

## Login page after
<img width="1479" height="859" alt="image" src="https://github.com/user-attachments/assets/9a25ff7f-c90f-47b1-a027-cbdc24867e7b" />

## Forgot page implemented 
<img width="1479" height="859" alt="image" src="https://github.com/user-attachments/assets/a8f669a1-82ba-4d6e-96b9-5589a28188f5" />

## Edit user Before 
<img width="1479" height="859" alt="image" src="https://github.com/user-attachments/assets/eef2f21d-268b-43d9-9a42-1a53b222030e" />


## Edit user after 
<img width="1479" height="859" alt="Screenshot from 2026-03-22 01-30-54" src="https://github.com/user-attachments/assets/3f598d85-fe0a-42ac-ac2d-7c6f24048167" />

# Out of scope
-  None
