### PR TITLE
feat(contacts): add contact status field with coloured chips

### DIFF
--- a/src/modules/contacts/ContactDetail.tsx
+++ b/src/modules/contacts/ContactDetail.tsx
@@ -41,6 +41,11 @@ import {
   localRoutes,
   appPermissions,
 } from '../../data/constants';
+import {
+  ContactStatus,
+  CONTACT_STATUS_LABELS,
+  CONTACT_STATUS_COLORS,
+} from '../../utils/types';
 import type { RootState } from '../../data/store';
 import { canViewTasks, hasAnyCapability } from '../../utils/permissions';
 import ContactForm from './ContactForm';
@@ -59,6 +64,7 @@ interface ContactData {
   placeOfWork?: string;
   ageGroup?: string;
   address?: string;
+  status?: ContactStatus;
   groupMemberships?: Array<{ group?: { id: number; name: string } }>;
   avatar?: string;
 }
@@ -91,6 +97,7 @@ function mapApiResponse(response: any): ContactData {
     placeOfWork: person.placeOfWork,
     ageGroup: person.ageGroup,
     address: addressParts.length > 0 ? addressParts.join(', ') : undefined,
+    status: response.status as ContactStatus | undefined,
     groupMemberships: response.groupMemberships,
   };
 }
@@ -250,6 +257,14 @@ const ContactDetail = () => {
               <Typography variant="h5" gutterBottom>
                 {fullName}
               </Typography>
+              {contact.status && (
+                <Chip
+                  label={CONTACT_STATUS_LABELS[contact.status]}
+                  color={CONTACT_STATUS_COLORS[contact.status]}
+                  size="small"
+                  sx={{ mb: 1 }}
+                />
+              )}
 
               <Box display="flex" flexDirection="column" gap={1} mt={3}>
                 {contact.email && (
@@ -393,6 +408,19 @@ const ContactDetail = () => {
                   Church Information
                 </Typography>
                 <List>
+                  <ListItem sx={{ gap: 2 }}>
+                    <ListItemIcon sx={{ minWidth: 'auto', fontSize: 28 }}>
+                      <PersonIcon />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary="Status"
+                      secondary={
+                        contact.status
+                          ? CONTACT_STATUS_LABELS[contact.status]
+                          : 'Active'
+                      }
+                    />
+                  </ListItem>
                   <ListItem sx={{ gap: 2 }}>
                     <ListItemIcon sx={{ minWidth: 'auto', fontSize: 28 }}>
                       <GroupIcon />

--- a/src/modules/contacts/ContactForm.tsx
+++ b/src/modules/contacts/ContactForm.tsx
@@ -24,6 +24,10 @@ import {
   post,
 } from '../../utils/ajax';
 import { remoteRoutes } from '../../data/constants';
+import {
+  ContactStatus,
+  CONTACT_STATUS_LABELS,
+} from '../../utils/types';
 
 const MONTHS = [
   'January', 'February', 'March', 'April', 'May', 'June',
@@ -41,6 +45,7 @@ interface ContactFormData {
   gender?: string;
   civilStatus?: string;
   placeOfWork?: string;
+  status?: ContactStatus;
   address?: {
     country?: string;
     district?: string;
@@ -81,6 +86,7 @@ const ContactForm = ({
     gender: '',
     civilStatus: '',
     placeOfWork: '',
+    status: ContactStatus.Active,
     address: {
       country: '',
       district: '',
@@ -158,6 +164,8 @@ const ContactForm = ({
             gender: person.gender || '',
             civilStatus: person.civilStatus || '',
             placeOfWork: person.placeOfWork || '',
+            status:
+              (response.status as ContactStatus) || ContactStatus.Active,
             address: {
               country: primaryAddress?.country || '',
               district: primaryAddress?.district || '',
@@ -236,6 +244,7 @@ const ContactForm = ({
         formData.address?.freeForm
           ? [{ category: 'Home', isPrimary: true, ...formData.address }]
           : [],
+      status: formData.status,
       // Now groups is an array of numbers like [12, 13]
       groups: selectedGroupIds.map((id) => ({ id })),
     };
@@ -403,6 +412,24 @@ const ContactForm = ({
               value={formData.placeOfWork}
               onChange={(e) => handleChange('placeOfWork', e.target.value)}
             />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <FormControl fullWidth>
+              <InputLabel>Status</InputLabel>
+              <Select
+                value={formData.status ?? ContactStatus.Active}
+                onChange={(e) =>
+                  handleChange('status', e.target.value as ContactStatus)
+                }
+                label="Status"
+              >
+                {(Object.values(ContactStatus) as ContactStatus[]).map((s) => (
+                  <MenuItem key={s} value={s}>
+                    {CONTACT_STATUS_LABELS[s]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
           </Grid>
 
           {/* Groups dropdown */}

--- a/src/modules/contacts/Contacts.tsx
+++ b/src/modules/contacts/Contacts.tsx
@@ -24,6 +24,7 @@ import {
   Card,
   CardContent,
   Stack,
+  Chip,
   Divider,
   useMediaQuery,
   useTheme,
@@ -39,6 +40,11 @@ import { search } from '../../utils/ajax';
 import { remoteRoutes, localRoutes } from '../../data/constants';
 import ContactForm from './ContactForm';
 import BulkUpload from './BulkUpload';
+import {
+  ContactStatus,
+  CONTACT_STATUS_LABELS,
+  CONTACT_STATUS_COLORS,
+} from '../../utils/types';
 
 interface Contact {
   id: string;
@@ -46,6 +52,7 @@ interface Contact {
   email: string;
   phone: string;
   dateOfBirth?: string;
+  status?: ContactStatus;
   location?: {
     id: string;
     name: string;
@@ -373,6 +380,20 @@ const Contacts = () => {
                       <Typography variant="caption" color="text.secondary">
                         Group: {contact.cellGroup?.name || 'Not assigned'}
                       </Typography>
+                      <Chip
+                        label={
+                          contact.status
+                            ? CONTACT_STATUS_LABELS[contact.status]
+                            : 'Active'
+                        }
+                        color={
+                          contact.status
+                            ? CONTACT_STATUS_COLORS[contact.status]
+                            : 'success'
+                        }
+                        size="small"
+                        sx={{ alignSelf: 'flex-start' }}
+                      />
                       <Typography variant="caption" color="text.secondary">
                         Birthday: {formatDate(contact.dateOfBirth)}
                       </Typography>
@@ -409,6 +430,11 @@ const Contacts = () => {
                       sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}
                     >
                       Group
+                    </TableCell>
+                    <TableCell
+                      sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}
+                    >
+                      Status
                     </TableCell>
                     <TableCell
                       sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}
@@ -479,6 +505,21 @@ const Contacts = () => {
                       </TableCell>
                       <TableCell sx={{ whiteSpace: 'nowrap' }}>
                         {contact.cellGroup?.name || '-'}
+                      </TableCell>
+                      <TableCell sx={{ whiteSpace: 'nowrap' }}>
+                        {contact.status ? (
+                          <Chip
+                            label={CONTACT_STATUS_LABELS[contact.status]}
+                            color={CONTACT_STATUS_COLORS[contact.status]}
+                            size="small"
+                          />
+                        ) : (
+                          <Chip
+                            label="Active"
+                            color="success"
+                            size="small"
+                          />
+                        )}
                       </TableCell>
                       <TableCell sx={{ whiteSpace: 'nowrap' }}>
                         {formatDate(contact.dateOfBirth)}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,35 @@
 export type $TsFixMe = any;
 
+// ─── Contact Status ───────────────────────────────────────────────────────────
+
+export const ContactStatus = {
+  Active: 'Active',
+  Inactive: 'Inactive',
+  MovedAway: 'MovedAway',
+  TransferredToAnotherChurch: 'TransferredToAnotherChurch',
+  Deceased: 'Deceased',
+} as const;
+export type ContactStatus = (typeof ContactStatus)[keyof typeof ContactStatus];
+
+export const CONTACT_STATUS_LABELS: Record<ContactStatus, string> = {
+  [ContactStatus.Active]: 'Active',
+  [ContactStatus.Inactive]: 'Inactive',
+  [ContactStatus.MovedAway]: 'Moved Away',
+  [ContactStatus.TransferredToAnotherChurch]: 'Transferred to Another Church',
+  [ContactStatus.Deceased]: 'Deceased',
+};
+
+export const CONTACT_STATUS_COLORS: Record<
+  ContactStatus,
+  'success' | 'default' | 'info' | 'warning' | 'error'
+> = {
+  [ContactStatus.Active]: 'success',
+  [ContactStatus.Inactive]: 'default',
+  [ContactStatus.MovedAway]: 'info',
+  [ContactStatus.TransferredToAnotherChurch]: 'warning',
+  [ContactStatus.Deceased]: 'error',
+};
+
 // ─── Tasks ────────────────────────────────────────────────────────────────────
 
 export const TaskType = {


### PR DESCRIPTION
Adds ContactStatus (Active, Inactive, MovedAway,
TransferredToAnotherChurch, Deceased) to the contacts module:

- utils/types.ts: ContactStatus const, label map, and colour map
- ContactForm: status dropdown in Additional Information section; defaults to Active on create, loads from API on edit
- ContactDetail: status chip below the contact name in the profile card, and a Status row in the Church Information section
- Contacts list: Status column in the desktop table and a chip on mobile cards; falls back to Active chip when field is absent

# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here
