### PR TITLE
Fix/signup default role member

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,6 +1,9 @@
 export const AUTH_TOKEN_KEY = '__demo__eva__token';
 export const AUTH_USER_KEY = '__demo__eva__user';
 
+export const appRoles = {
+  RoleAdmin: 'RoleAdmin',
+}
 export const appPermissions = {
   roleDashboard: 'DASHBOARD',
   roleCrmView: 'CRM_VIEW',

--- a/src/modules/groups/GroupDetails.tsx
+++ b/src/modules/groups/GroupDetails.tsx
@@ -23,8 +23,7 @@ import { get, del, put } from '../../utils/ajax';
 import {
   remoteRoutes,
   localRoutes,
-  appPermissions,
-  appRoles,
+  appPermissions
 } from '../../data/constants';
 import type { RootState } from '../../data/store';
 import { hasAnyCapability } from '../../utils/permissions';
@@ -631,7 +630,7 @@ const GroupDetails = () => {
                     />
                   </Box>
 
-                  {canManageCurrentGroup && user?.roles?.includes(appRoles.RoleAdmin) ? (
+                  {canManageCurrentGroup ? (
                     <Button
                       size="small"
                       variant="outlined"

--- a/src/modules/groups/GroupDetails.tsx
+++ b/src/modules/groups/GroupDetails.tsx
@@ -24,6 +24,7 @@ import {
   remoteRoutes,
   localRoutes,
   appPermissions,
+  appRoles,
 } from '../../data/constants';
 import type { RootState } from '../../data/store';
 import { hasAnyCapability } from '../../utils/permissions';
@@ -630,7 +631,7 @@ const GroupDetails = () => {
                     />
                   </Box>
 
-                  {canManageCurrentGroup ? (
+                  {canManageCurrentGroup && user?.roles?.includes(appRoles.RoleAdmin) ? (
                     <Button
                       size="small"
                       variant="outlined"

--- a/src/modules/login/SignUp.tsx
+++ b/src/modules/login/SignUp.tsx
@@ -244,7 +244,7 @@ const SignUp = () => {
         email: formData.email,
         password: formData.password,
         groupId: selectedLocationId,
-        groupRole: 'Leader',
+        groupRole: 'Member',
         churchName: formData.churchName,
       },
       () => {


### PR DESCRIPTION
# Ticket No
- Ticket number here

# Summary of changes
- When signing up, the default role is `Member`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated new account sign-ups to assign the correct default group role as **Member**.
* **Chores**
  * Added a new role value to support role-based access and group membership handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->