### PR TITLE
Feat/contact group parent label

### DIFF
--- a/src/modules/contacts/ContactForm.tsx
+++ b/src/modules/contacts/ContactForm.tsx
@@ -66,7 +66,7 @@ type GroupNode = {
   name: string;
   children?: GroupNode[];
 };
-type GroupOption = { id: number; name: string };
+type GroupOption = { id: number; name: string; parentName?: string };
 
 const ContactForm = ({
   contactId,
@@ -101,20 +101,21 @@ const ContactForm = ({
   const [groupsOptions, setGroupsOptions] = useState<GroupOption[]>([]);
   const [selectedGroupIds, setSelectedGroupIds] = useState<number[]>([]);
 
-  // Flatten hierarchical groups into simple id/name array
-  const flattenGroups = (nodes: GroupNode[] | undefined): GroupOption[] => {
+  // Flatten hierarchical groups, preserving parent name for display
+  const flattenGroups = (nodes: GroupNode[] | undefined, parentName?: string): GroupOption[] => {
     const out: GroupOption[] = [];
-    const stack: GroupNode[] = [...(nodes || [])];
-    while (stack.length) {
-      const n = stack.pop() as GroupNode;
-      out.push({ id: n.id, name: n.name });
-      if (n.children && n.children.length) {
-        for (let i = 0; i < n.children.length; i++) stack.push(n.children[i]);
+    for (const n of (nodes || [])) {
+      out.push({ id: n.id, name: n.name, parentName });
+      if (n.children?.length) {
+        out.push(...flattenGroups(n.children, n.name));
       }
     }
     out.sort((a, b) => a.name.localeCompare(b.name));
     return out;
   };
+
+  const getGroupLabel = (option: GroupOption) =>
+    option.parentName ? `${option.name} - ${option.parentName}` : option.name;
 
   // Fetch groups once
   useEffect(() => {
@@ -445,7 +446,7 @@ const ContactForm = ({
                 onChange={(_, newValue) => {
                   setSelectedGroupIds(newValue.map((g) => g.id));
                 }}
-                getOptionLabel={(option) => option.name}
+                getOptionLabel={getGroupLabel}
                 filterSelectedOptions
                 renderInput={(params) => (
                   <TextField
@@ -454,10 +455,9 @@ const ContactForm = ({
                     placeholder="Type to search groups"
                   />
                 )}
-                // To show ID in option list
                 renderOption={(props, option) => (
                   <li {...props} key={option.id}>
-                    {option.name}
+                    {getGroupLabel(option)}
                   </li>
                 )}
                 isOptionEqualToValue={(opt, val) => opt.id === val.id}

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -428,7 +428,7 @@ const ReportSubmissionForm = () => {
       if (field.type === 'select' && isDynamicScheduleField(field)) {
         fetchFellowshipSchedule(field);
       }
-      if (field.type === 'checkbox' && isDynamicMemberField(field)) {
+      if (isDynamicMemberField(field)) {
         fetchFellowshipMembers(field);
       }
     });
@@ -607,7 +607,7 @@ const ReportSubmissionForm = () => {
     }
 
     // Fellowship member checklist
-    if (field.type === 'checkbox' && isDynamicMemberField(field)) {
+    if ((field.type === 'checkbox' || field.type === 'select') && isDynamicMemberField(field)) {
       const members = fellowshipMembers[field.name] || [];
       const isLoading = dynamicLoading[field.name];
       const memberSearchVal = memberSearch[field.name] || '';


### PR DESCRIPTION
# Ticket No
- Golive103

# Summary of changes
- Display MC member names and select the ones to submit in the MC report.
- Since groups will have many similar names, MCs and zones, we are now displaying the 'child - parent' but as you select, the child is recorded

# How should this be tested? [Screenshots, Video or Type instructions]
- 
<img width="766" height="518" alt="image" src="https://github.com/user-attachments/assets/d0ce5dee-5121-4460-af8c-dfbdaf508cbc" />

<img width="766" height="518" alt="image" src="https://github.com/user-attachments/assets/fdae026c-b415-4306-a03b-381b2a3e839d" />


# Notes for reviewers
- 

# Out of scope
-  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group selectors now show clearer labels for nested groups, including parent group names when available.
  * Dynamic member selection is now available for both checkbox and select fields in report submission forms.

* **Bug Fixes**
  * Improved how group lists are displayed and sorted in contact forms.
  * Expanded automatic member loading so dynamic member fields populate consistently across supported field types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->