### PR TITLE
Fix/report button dark mode

### DIFF
--- a/src/modules/dashboard/Dashboard.tsx
+++ b/src/modules/dashboard/Dashboard.tsx
@@ -322,10 +322,6 @@ const Dashboard = () => {
                 startIcon={<SendRoundedIcon />}
                 onClick={() => navigate(`/reports/${report.id}/submit`)}
                 sx={{
-                  backgroundColor: 'success.main',
-                  '&:hover': { backgroundColor: 'success.dark',
-                    color: (theme) => theme.palette.mode === 'dark' ? '#ffffff' : 'text.primary'
- },
                   fontWeight: 600,
                   textTransform: 'none',
                 }}

--- a/src/modules/dashboard/Dashboard.tsx
+++ b/src/modules/dashboard/Dashboard.tsx
@@ -324,7 +324,7 @@ const Dashboard = () => {
                 sx={{
                   backgroundColor: 'success.main',
                   '&:hover': { backgroundColor: 'success.dark',
-                    color: (theme) => theme.palette.mode === 'dark' ? '#ffffff' : undefined
+                    color: (theme) => theme.palette.mode === 'dark' ? '#ffffff' : 'text.primary'
  },
                   fontWeight: 600,
                   textTransform: 'none',

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -971,10 +971,6 @@ const ReportSubmissionForm = () => {
             onClick={handleSubmit}
             disabled={submitting}
             sx={{
-              backgroundColor: '#1b813e',
-              '&:hover': { backgroundColor: '#15662f', 
-                    color: (theme) => theme.palette.mode === 'dark' ? '#ffffff' : 'text.primary'
- },
               fontWeight: 'bold',
             }}
           >

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -973,7 +973,7 @@ const ReportSubmissionForm = () => {
             sx={{
               backgroundColor: '#1b813e',
               '&:hover': { backgroundColor: '#15662f', 
-                    color: (theme) => theme.palette.mode === 'dark' ? '#ffffff' : undefined
+                    color: (theme) => theme.palette.mode === 'dark' ? '#ffffff' : 'text.primary'
  },
               fontWeight: 'bold',
             }}


### PR DESCRIPTION
# Ticket No
- UI-REPORT-01

# Summary of changes
- Refactored the report submission and form buttons to match the established visual design standards of other core components across the system (e.g., the 'Need Help' button).
- Fixed a high-contrast visibility bug where the text on green background buttons defaulted to an unreadable black color when running in dark mode.

# How should this be tested? 
1. Open the application and toggle the global interface style over to Dark Mode.
2. Navigate to a dashboard containing standard layout buttons (like the 'Need Help' button) and compare them to the report landing page buttons.
3. Verify that the button font weight, sizing, and text transformations are visually uniform across these elements.
4. Observe that the report button text displays clearly in white against its green background.
5. Move your mouse cursor directly over the button to trigger the hover state and verify that the text remains crisp and pure white without dimming or shifting to black.

# Notes for reviewers
- The Report buttons now have consistent styles with the 'need help?' button

# Out of scope
- Editing structural configuration objects inside the global `src/theme.ts` file.

