### PR TITLE
fix(contacts): remove duplicate MONTHS and DAYS constants in ContactForm

### DIFF
--- a/src/modules/contacts/ContactForm.tsx
+++ b/src/modules/contacts/ContactForm.tsx
@@ -35,12 +35,6 @@ const MONTHS = [
 ];
 const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
 
-const MONTHS = [
-  'January', 'February', 'March', 'April', 'May', 'June',
-  'July', 'August', 'September', 'October', 'November', 'December',
-];
-const DAYS = Array.from({ length: 31 }, (_, i) => i + 1);
-
 interface ContactFormData {
   firstName: string;
   lastName: string;


### PR DESCRIPTION
Merge artifact left both constant declarations in the file, causing TS2451 redeclaration errors that broke the production build.

# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here
