### PR TITLE
Fix dashboard render errors

### DIFF
--- a/src/components/layout-v2/Header.tsx
+++ b/src/components/layout-v2/Header.tsx
@@ -141,21 +141,19 @@ export default function Header() {
               }}
             >
               {userLocations.length > 0 && (
-                <>
-                  <MenuItem
-                    disabled
-                    sx={{ opacity: '1 !important', pointerEvents: 'none' }}
-                  >
-                    <ListItemIcon>
-                      <LocationOnRoundedIcon fontSize="small" />
-                    </ListItemIcon>
-                    <Typography variant="body2" color="text.secondary">
-                      {userLocations.map((l) => l.name).join(', ')}
-                    </Typography>
-                  </MenuItem>
-                  <Divider />
-                </>
+                <MenuItem
+                  disabled
+                  sx={{ opacity: '1 !important', pointerEvents: 'none' }}
+                >
+                  <ListItemIcon>
+                    <LocationOnRoundedIcon fontSize="small" />
+                  </ListItemIcon>
+                  <Typography variant="body2" color="text.secondary">
+                    {userLocations.map((l) => l.name).join(', ')}
+                  </Typography>
+                </MenuItem>
               )}
+              {userLocations.length > 0 && <Divider />}
               <MenuItem onClick={handleLogout}>
                 <ListItemIcon>
                   <LogoutRoundedIcon fontSize="small" />

--- a/src/modules/dashboard/Dashboard.tsx
+++ b/src/modules/dashboard/Dashboard.tsx
@@ -61,7 +61,7 @@ interface RecentSubmission {
 }
 
 interface PgaTrendPoint {
-  period: string;
+  period: string | null;
   total: number;
 }
 
@@ -205,7 +205,10 @@ const Dashboard = () => {
     'Past Month';
 
   const recentSubmissions = dashboardData?.recentSubmissions || [];
-  const pgaTrend = dashboardData?.pgaTrend || [];
+  const pgaTrend = (dashboardData?.pgaTrend || []).filter(
+    (point): point is PgaTrendPoint & { period: string } =>
+      typeof point.period === 'string' && point.period.length > 0,
+  );
   const locationRanking = dashboardData?.locationRanking || [];
 
   const handleMenuOpen = (
@@ -236,6 +239,10 @@ const Dashboard = () => {
 
   const formatPeriodLabel = (period: string) => {
     const [year, month, day] = period.split('-').map(Number);
+    if (!year || !month || !day) {
+      return period;
+    }
+
     return new Date(year, month - 1, day).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',


### PR DESCRIPTION
Fix the MUI Menu fragment issue in Header by rendering the location item and divider as direct Menu children. Filter dashboard PGA trend rows with null or empty periods before rendering the chart, and keep period label formatting defensive for malformed dates.

# Ticket No
-  GoLive104

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard chart labeling by handling missing or invalid period values more safely, preventing malformed date labels from appearing.
  * Updated the user profile menu so the location list option and divider continue to appear together only when locations are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->