### PR TITLE
fix: handle serviceLocationName field and skip validation for hidden …

### DIFF
--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -540,7 +540,7 @@ const ReportSubmissionForm = () => {
     if (Object.keys(errors).length > 0 || hiddenFieldMissing) {
       setValidationErrors(errors);
       toast.error(
-        hiddenFieldMissing
+        hiddenFieldMissing && Object.keys(errors).length === 0
           ? 'Some required information failed to load. Please refresh and try again.'
           : 'Please fill out all required fields',
       );

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -245,6 +245,9 @@ const ReportSubmissionForm = () => {
   const isSmallGroupNameField = (field: IReportField): boolean =>
     field.name === 'smallGroupName';
 
+  const isServiceLocationNameField = (field: IReportField): boolean =>
+    field.name === 'serviceLocationName';
+
   const handleChange = (name: string, value: $TsFixMe) => {
     setFormData((prev) => ({ ...prev, [name]: value }));
     setValidationErrors((prev) => {
@@ -276,12 +279,42 @@ const ReportSubmissionForm = () => {
     });
   };
 
-  const handleDynamicGroupChange = (fieldName: string, group: DynamicGroup) => {
-    const lowerName = fieldName.toLowerCase();
+  const handleServiceLocationChange = (group: DynamicGroup | null) => {
+    setFormData((prev) => {
+      const next = { ...prev };
+
+      if (group) {
+        next.serviceLocationName = group.name;
+        next.serviceLocationId = group.id;
+      } else {
+        delete next.serviceLocationName;
+        delete next.serviceLocationId;
+      }
+
+      return next;
+    });
+
+    setValidationErrors((prev) => {
+      const next = { ...prev };
+      delete next.serviceLocationName;
+      return next;
+    });
+  };
+
+  const handleDynamicGroupChange = (
+    field: IReportField,
+    group: DynamicGroup,
+  ) => {
+    if (isServiceLocationNameField(field)) {
+      handleServiceLocationChange(group);
+      return;
+    }
+
+    const lowerName = field.name.toLowerCase();
     if (lowerName.includes('id')) {
-      handleChange(fieldName, group.id);
+      handleChange(field.name, group.id);
     } else {
-      handleChange(fieldName, group.name);
+      handleChange(field.name, group.name);
     }
   };
 
@@ -317,7 +350,7 @@ const ReportSubmissionForm = () => {
 
         // Auto-select if only one option
         if (groups.length === 1) {
-          handleDynamicGroupChange(field.name, groups[0]);
+          handleDynamicGroupChange(field, groups[0]);
         }
       },
       (error: $TsFixMe) => {
@@ -487,7 +520,7 @@ const ReportSubmissionForm = () => {
   const handleSubmit = () => {
     const errors: Record<string, string> = {};
     reportFields.forEach((field) => {
-      if (field.required) {
+      if (field.required && !field.hidden) {
         const value = formData[field.name];
         const isEmpty =
           field.type === 'checkbox' ||
@@ -795,7 +828,7 @@ const ReportSubmissionForm = () => {
               const selected = groups.find((g) =>
                 useId ? g.id === e.target.value : g.name === e.target.value,
               );
-              if (selected) handleDynamicGroupChange(field.name, selected);
+              if (selected) handleDynamicGroupChange(field, selected);
             }}
             sx={autoSelected ? { backgroundColor: 'success.50' } : undefined}
           >

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -297,6 +297,7 @@ const ReportSubmissionForm = () => {
     setValidationErrors((prev) => {
       const next = { ...prev };
       delete next.serviceLocationName;
+      delete next.serviceLocationId;
       return next;
     });
   };
@@ -519,23 +520,30 @@ const ReportSubmissionForm = () => {
 
   const handleSubmit = () => {
     const errors: Record<string, string> = {};
+    let hiddenFieldMissing = false;
     reportFields.forEach((field) => {
-      if (field.required && !field.hidden) {
-        const value = formData[field.name];
-        const isEmpty =
-          field.type === 'checkbox' ||
-          (field.type === 'select' && isDynamicMemberField(field))
-            ? !Array.isArray(value) || value.length === 0
-            : value === undefined || value === null || value === '';
-        if (isEmpty) {
-          errors[field.name] = `${field.label || field.name} is required`;
-        }
+      if (!field.required) return;
+      const value = formData[field.name];
+      const isEmpty =
+        field.type === 'checkbox' ||
+        (field.type === 'select' && isDynamicMemberField(field))
+          ? !Array.isArray(value) || value.length === 0
+          : value === undefined || value === null || value === '';
+      if (!isEmpty) return;
+      if (field.hidden) {
+        hiddenFieldMissing = true;
+      } else {
+        errors[field.name] = `${field.label || field.name} is required`;
       }
     });
 
-    if (Object.keys(errors).length > 0) {
+    if (Object.keys(errors).length > 0 || hiddenFieldMissing) {
       setValidationErrors(errors);
-      toast.error('Please fill out all required fields');
+      toast.error(
+        hiddenFieldMissing
+          ? 'Some required information failed to load. Please refresh and try again.'
+          : 'Please fill out all required fields',
+      );
       return;
     }
 
@@ -826,7 +834,7 @@ const ReportSubmissionForm = () => {
             label={`${field.label}${field.required ? ' *' : ''}`}
             onChange={(e) => {
               const selected = groups.find((g) =>
-                useId ? g.id === e.target.value : g.name === e.target.value,
+                useId ? String(g.id) === e.target.value : g.name === e.target.value,
               );
               if (selected) handleDynamicGroupChange(field, selected);
             }}


### PR DESCRIPTION
handle serviceLocationName field and skip validation for hidden fields

Adds dedicated handling for serviceLocationName so both name and id are kept in sync, and excludes hidden fields from required-field validation on submit.

# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic group fields now support a dedicated service location name, with linked updates to the related location selection.
  * Auto-selection for dynamic group selectors now works with the updated selection flow.

* **Bug Fixes**
  * Improved handling of required hidden fields during submission, showing a clearer refresh-and-try-again message instead of a field-specific error.
  * Fixed option matching in dynamic group selectors so selected values compare reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->