### PR TITLE
fix(Login/SignUp)

### DIFF
--- a/src/modules/login/HelpFab.tsx
+++ b/src/modules/login/HelpFab.tsx
@@ -6,7 +6,7 @@ const HELP_URL = 'https://linktr.ee/AtProjectZoe';
 // Below this width the extended "Need Help?" pill can overlap the
 // "Already have an account? / Don't have an account?" links on the
 // login/register forms, so it collapses to an icon-only circular FAB.
-const NARROW_SCREEN_QUERY = '@media (max-width: 500px)';
+export const NARROW_SCREEN_QUERY = '@media (max-width: 500px)';
 
 const HelpFab = () => (
   <Tooltip title="Need help? Click Me!" placement="left">

--- a/src/modules/login/HelpFab.tsx
+++ b/src/modules/login/HelpFab.tsx
@@ -1,10 +1,15 @@
-import { Fab, Tooltip } from '@mui/material';
+import { Box, Fab, Tooltip } from '@mui/material';
 import HelpOutlineRoundedIcon from '@mui/icons-material/HelpOutlineRounded';
 
 const HELP_URL = 'https://linktr.ee/AtProjectZoe';
 
+// Below this width the extended "Need Help?" pill can overlap the
+// "Already have an account? / Don't have an account?" links on the
+// login/register forms, so it collapses to an icon-only circular FAB.
+const NARROW_SCREEN_QUERY = '@media (max-width: 500px)';
+
 const HelpFab = () => (
-  <Tooltip title="Need help? Click this button and get in touch with us" placement="left">
+  <Tooltip title="Need help? Click Me!" placement="left">
     <Fab
       variant="extended"
       color="primary"
@@ -21,17 +26,25 @@ const HelpFab = () => (
         textTransform: 'none',
         fontWeight: 600,
         '[data-mui-color-scheme="dark"] &': {
-        backgroundColor: '#ffffff',
-        color: '#000000',
-        '&:hover': {
-          backgroundColor: '#f5f5f5',
+          backgroundColor: '#ffffff',
+          color: '#000000',
+          '&:hover': {
+            backgroundColor: '#f5f5f5',
+          },
         },
-      },
-
+        [NARROW_SCREEN_QUERY]: {
+          minWidth: 0,
+          width: 48,
+          height: 48,
+          borderRadius: '50%',
+          px: 0,
+        },
       }}
     >
-      <HelpOutlineRoundedIcon sx={{ mr: 1 }} />
-      Need Help?
+      <HelpOutlineRoundedIcon sx={{ mr: 1, [NARROW_SCREEN_QUERY]: { mr: 0 } }} />
+      <Box component="span" sx={{ [NARROW_SCREEN_QUERY]: { display: 'none' } }}>
+        Need Help?
+      </Box>
     </Fab>
   </Tooltip>
 );

--- a/src/modules/login/Login.tsx
+++ b/src/modules/login/Login.tsx
@@ -146,6 +146,11 @@ const Login = () => {
           p: { xs: 3, sm: 6 },
           pt: { xs: 4, sm: 6 },
           backgroundColor: 'background.paper',
+          // Extra bottom clearance so the fixed Need Help FAB never covers
+          // the "Don't have an account?" link on narrow screens.
+          '@media (max-width: 500px)': {
+            pb: 10,
+          },
         }}
       >
         <Box sx={{ width: '100%', maxWidth: 400 }}>

--- a/src/modules/login/Login.tsx
+++ b/src/modules/login/Login.tsx
@@ -17,7 +17,7 @@ import { login } from '../../data/coreSlice';
 import { post } from '../../utils/ajax';
 import { remoteRoutes, localRoutes } from '../../data/constants';
 import loginBackground from '../../assets/images/login-background.jpg';
-import HelpFab from './HelpFab';
+import HelpFab, { NARROW_SCREEN_QUERY } from './HelpFab';
 
 const Login = () => {
   const dispatch = useDispatch();
@@ -148,7 +148,7 @@ const Login = () => {
           backgroundColor: 'background.paper',
           // Extra bottom clearance so the fixed Need Help FAB never covers
           // the "Don't have an account?" link on narrow screens.
-          '@media (max-width: 500px)': {
+          [NARROW_SCREEN_QUERY]: {
             pb: 10,
           },
         }}

--- a/src/modules/login/SignUp.tsx
+++ b/src/modules/login/SignUp.tsx
@@ -365,6 +365,11 @@ const SignUp = () => {
           p: { xs: 3, sm: 6 },
           pt: { xs: 4, sm: 6 },
           backgroundColor: 'background.paper',
+          // Extra bottom clearance so the fixed Need Help FAB never covers
+          // the "Already have an account?" link on narrow screens.
+          '@media (max-width: 500px)': {
+            pb: 10,
+          },
         }}
       >
         <Box sx={{ width: '100%', maxWidth: 400 }}>

--- a/src/modules/login/SignUp.tsx
+++ b/src/modules/login/SignUp.tsx
@@ -20,7 +20,7 @@ import { toast } from 'react-toastify';
 import { post } from '../../utils/ajax';
 import { remoteRoutes, localRoutes } from '../../data/constants';
 import loginBackground from '../../assets/images/login-background.jpg';
-import HelpFab from './HelpFab';
+import HelpFab, { NARROW_SCREEN_QUERY } from './HelpFab';
 
 interface Location {
   id: number;
@@ -367,7 +367,7 @@ const SignUp = () => {
           backgroundColor: 'background.paper',
           // Extra bottom clearance so the fixed Need Help FAB never covers
           // the "Already have an account?" link on narrow screens.
-          '@media (max-width: 500px)': {
+          [NARROW_SCREEN_QUERY]: {
             pb: 10,
           },
         }}


### PR DESCRIPTION
In the form panels — reserve clearance below the sign-in/sign-up link so the fixed FAB never sits over it

# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the “Need Help?” button on small screens so it collapses into a compact icon-only button for better mobile usability.
* **Bug Fixes**
  * Added extra spacing on login and sign-up screens at narrow widths to prevent the help button from covering important account links.
  * Refined tooltip and button behavior to keep the help action accessible while saving space on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->