### PR TITLE
feat(ContactDetails): Ease of navigation

### DIFF
--- a/src/modules/contacts/ContactDetail.tsx
+++ b/src/modules/contacts/ContactDetail.tsx
@@ -292,6 +292,10 @@ const ContactDetail = () => {
                         label={gm.group.name}
                         color="primary"
                         size="medium"
+                        clickable
+                        onClick={() =>
+                          navigate(`${localRoutes.groups}/${gm.group!.id}`)
+                        }
                       />
                     ),
                 )}


### PR DESCRIPTION
# Ticket No
- GoLive112

# Summary of changes
- On clicking the group chip, the user can now navigate to a group details page

# How should this be tested? [Screenshots, Video or Type instructions]
- Try clicking on any group chip, under contact details.

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Group membership chips in contact profiles are now interactive and can be selected to open the related group page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->