### PR TITLE
fix(fellowship): allow MC leaders to create schedule inline from report form

### DIFF
--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -77,6 +77,7 @@ interface FellowshipMember {
 
 interface ScheduleData {
   exists: boolean;
+  isLeader?: boolean;
   id?: number;
   day?: number;
   label?: string;
@@ -496,26 +497,26 @@ const ReportSubmissionForm = () => {
   const handleScheduleSave = () => {
     if (!scheduleEditFieldName) return;
     const schedule = fellowshipSchedules[scheduleEditFieldName];
-    if (!schedule?.id) return;
+    const payload = { meetingDay: scheduleEditDay, startTime: scheduleEditTime, frequency: scheduleEditFrequency };
 
     setScheduleEditSaving(true);
-    put(
-      `${remoteRoutes.fellowships}/schedules/${schedule.id}`,
-      { meetingDay: scheduleEditDay, startTime: scheduleEditTime, frequency: scheduleEditFrequency },
-      () => {
-        // Re-fetch so the display and form value both update
-        const field = reportFields.find((f) => f.name === scheduleEditFieldName);
-        if (field) fetchFellowshipSchedule(field);
-        setScheduleEditOpen(false);
-        setScheduleEditSaving(false);
-        toast.success('Meeting schedule updated');
-      },
-      (error: $TsFixMe) => {
-        const message = error?.response?.data?.message || 'Failed to update schedule';
-        toast.error(message);
-        setScheduleEditSaving(false);
-      },
-    );
+    const onSuccess = () => {
+      const field = reportFields.find((f) => f.name === scheduleEditFieldName);
+      if (field) fetchFellowshipSchedule(field);
+      setScheduleEditOpen(false);
+      setScheduleEditSaving(false);
+      toast.success(schedule?.id ? 'Meeting schedule updated' : 'Meeting schedule created');
+    };
+    const onError = (error: $TsFixMe) => {
+      toast.error(error?.response?.data?.message || 'Failed to save schedule');
+      setScheduleEditSaving(false);
+    };
+
+    if (schedule?.id) {
+      put(`${remoteRoutes.fellowships}/schedules/${schedule.id}`, payload, onSuccess, onError);
+    } else {
+      post(`${remoteRoutes.fellowships}/schedules`, { ...payload, fellowshipGroupId: schedule?.fellowshipGroupId }, onSuccess, onError);
+    }
   };
 
   const handleSubmit = () => {
@@ -686,10 +687,36 @@ const ReportSubmissionForm = () => {
         );
       }
 
-      // Fallback: no schedule (edge case after auto-creation is in place)
+      if (schedule?.fellowshipGroupId) {
+        return (
+          <Alert
+            severity="warning"
+            variant="outlined"
+            action={
+              <Button
+                size="small"
+                onClick={() => {
+                  setScheduleEditFieldName(field.name);
+                  setScheduleEditDay(3);
+                  setScheduleEditTime('19:00');
+                  setScheduleEditFrequency('weekly');
+                  setScheduleEditOpen(true);
+                }}
+              >
+                Set up
+              </Button>
+            }
+          >
+            No meeting schedule set for your MC.
+          </Alert>
+        );
+      }
+
       return (
-        <Alert severity="warning" variant="outlined">
-          No meeting schedule found for your MC. Contact your administrator.
+        <Alert severity="info" variant="outlined">
+          {schedule?.isLeader === false
+            ? 'You are not assigned as a leader of any Missional Community.'
+            : 'No meeting schedule found for your MC. Contact your administrator.'}
         </Alert>
       );
     }


### PR DESCRIPTION
## Summary
- MC leaders with no schedule now see a "Set up" button instead of a dead-end admin contact message
- On save, branches on `schedule.id`: `PUT` to update an existing schedule, `POST` to create a new one
- Non-leaders see "You are not assigned as a leader of any Missional Community" using the new `isLeader` flag from the API
- All logic remains scoped inside `isDynamicScheduleField` — no coupling to any specific report or field name

## Dependencies
Requires server PR: https://github.com/kanzucodefoundation/project-zoe-server/pull/new/fix/fellowship-schedule-setup

## Test plan
- [ ] User who is not an MC leader sees the "not assigned as leader" message
- [ ] MC leader with no schedule sees "Set up" button; clicking it opens the schedule dialog with Wednesday 7pm defaults
- [ ] Submitting the dialog creates a schedule and re-renders the field showing the new schedule
- [ ] MC leader with existing schedule sees it displayed with a "Change" button that updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)