### PR TITLE
fix(reports): show group picker when leader belongs to multiple groups

### DIFF
--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -174,12 +174,15 @@ const ReportSubmissionForm = () => {
 
   const [reportName, setReportName] = useState('');
   const [reportFields, setReportFields] = useState<IReportField[]>([]);
+  const [targetCategoryId, setTargetCategoryId] = useState<number | null>(null);
   const [formData, setFormData] = useState<Record<string, $TsFixMe>>({});
   const [validationErrors, setValidationErrors] = useState<
     Record<string, string>
   >({});
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+  const [groupChoices, setGroupChoices] = useState<DynamicGroup[]>([]);
+  const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
   const [dynamicOptions, setDynamicOptions] = useState<
     Record<string, DynamicGroup[]>
   >({});
@@ -209,6 +212,37 @@ const ReportSubmissionForm = () => {
         if (Array.isArray(response.fields)) {
           setReportFields(response.fields);
           setReportName(response.name || 'Submit Report');
+
+          const categoryId = response.targetGroupCategory?.id ?? null;
+          setTargetCategoryId(categoryId);
+
+          // If the report already has a dynamic_group_selector field, it handles
+          // group selection itself — no need for the form-level picker.
+          const hasGroupSelector = response.fields.some(
+            (f: IReportField) =>
+              Array.isArray(f.options) &&
+              f.options.some(
+                (o: $TsFixMe) => o?.type === 'dynamic_group_selector',
+              ),
+          );
+
+          if (categoryId && !hasGroupSelector) {
+            get(
+              remoteRoutes.groupsMyGroups,
+              (groups: $TsFixMe[]) => {
+                const inCategory = (Array.isArray(groups) ? groups : []).filter(
+                  (g) => g.categoryId === categoryId,
+                );
+                if (inCategory.length > 1) {
+                  setGroupChoices(inCategory);
+                } else if (inCategory.length === 1) {
+                  setSelectedGroupId(inCategory[0].id);
+                }
+              },
+              (err: $TsFixMe) =>
+                console.error('Failed to fetch user groups:', err),
+            );
+          }
         } else {
           toast.error('Failed to load report fields');
         }
@@ -549,10 +583,14 @@ const ReportSubmissionForm = () => {
 
     setSubmitting(true);
 
-    // Backend expects: { data: { fieldName: value, ... } }
-    const submissionData = {
-      data: formData,
-    };
+    if (groupChoices.length > 1 && !selectedGroupId) {
+      toast.error('Please select which group you are submitting this report for');
+      setSubmitting(false);
+      return;
+    }
+
+    const submissionData: Record<string, $TsFixMe> = { data: formData };
+    if (selectedGroupId) submissionData.selectedGroupId = selectedGroupId;
 
     // Use correct endpoint: POST /api/reports/:reportId/submissions
     post(
@@ -1001,6 +1039,26 @@ const ReportSubmissionForm = () => {
       </Typography>
 
       <Box display="flex" flexDirection="column" gap={3}>
+        {groupChoices.length > 1 && (
+          <FormControl required error={!selectedGroupId}>
+            <InputLabel>Which group are you submitting for?</InputLabel>
+            <Select
+              value={selectedGroupId ?? ''}
+              label="Which group are you submitting for?"
+              onChange={(e) => setSelectedGroupId(Number(e.target.value))}
+            >
+              {groupChoices.map((g) => (
+                <MenuItem key={g.id} value={g.id}>
+                  {g.name}
+                </MenuItem>
+              ))}
+            </Select>
+            {!selectedGroupId && (
+              <FormHelperText>Select a group to continue</FormHelperText>
+            )}
+          </FormControl>
+        )}
+
         {reportFields.map((field) => (
           <Box key={field.name}>{renderField(field)}</Box>
         ))}


### PR DESCRIPTION
## Summary
- On form load, fetches the user's groups and filters by the report's `targetGroupCategory`
- If multiple groups found and no `dynamic_group_selector` field exists, shows a dropdown at the top of the form before any fields
- If exactly one group found, silently pre-selects it (no UI change for single-group leaders)
- Selected group ID is passed as `selectedGroupId` in the submission payload
- Blocks submission with a clear message if multi-group user hasn't selected a group yet

## Dependencies
Requires server PR: https://github.com/kanzucodefoundation/project-zoe-server/pull/new/fix/multi-group-report-submission

## Test plan
- [ ] Single-group leader: no picker shown, form works as before
- [ ] Multi-group leader: picker appears at top, submission blocked until a group is selected
- [ ] Report with existing `dynamic_group_selector` field: picker does NOT appear (field handles it)
- [ ] Selecting a group and submitting succeeds and attributes to the correct group

🤖 Generated with [Claude Code](https://claude.com/claude-code)