### PR TITLE
fix(reports): remove unused targetCategoryId state (TS6133 build error)

### DIFF
--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -175,7 +175,6 @@ const ReportSubmissionForm = () => {
 
   const [reportName, setReportName] = useState('');
   const [reportFields, setReportFields] = useState<IReportField[]>([]);
-  const [targetCategoryId, setTargetCategoryId] = useState<number | null>(null);
   const [formData, setFormData] = useState<Record<string, $TsFixMe>>({});
   const [validationErrors, setValidationErrors] = useState<
     Record<string, string>
@@ -215,7 +214,6 @@ const ReportSubmissionForm = () => {
           setReportName(response.name || 'Submit Report');
 
           const categoryId = response.targetGroupCategory?.id ?? null;
-          setTargetCategoryId(categoryId);
 
           // If the report already has a dynamic_group_selector field, it handles
           // group selection itself — no need for the form-level picker.


### PR DESCRIPTION
## Summary
Removes the unused `targetCategoryId` state variable introduced in #211. The `categoryId` local variable derived from the report response is used directly inline, so the state was never needed.

Fixes the TypeScript build error:
```
error TS6133: 'targetCategoryId' is declared but its value is never read.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)