### PR TITLE
feat/group-member-click-navigation

### DIFF
--- a/src/modules/groups/GroupDetails.tsx
+++ b/src/modules/groups/GroupDetails.tsx
@@ -754,9 +754,11 @@ const GroupDetails = () => {
                   flexDirection={{ xs: 'column', sm: 'row' }}
                   gap={2}
                   p={1.5}
-                  sx={{
+                  sx={{                    
                     bgcolor: 'action.hover',
                     borderRadius: 1,
+                    cursor: 'pointer',
+                    '&:hover': { bgcolor: 'action.selected' }, 
                   }}
                 >
                   <Box
@@ -767,11 +769,18 @@ const GroupDetails = () => {
                     flexGrow={1}
                     width={{ xs: '100%', sm: 'auto' }}
                     minWidth={0}
+                    onClick={() => navigate(`${localRoutes.contacts}/${membership.contactId || membership.contact?.id}`)}
                   >
-                    <Typography variant="body2" noWrap sx={{ minWidth: 0 }}>
-                      {membership.contact?.name ||
-                        `Contact #${membership.contactId}`}
-                    </Typography>
+                    <Typography 
+                      variant="body2" 
+                      noWrap 
+                      sx={{ 
+                        minWidth: 0,
+                        fontWeight: 500,
+                      }}
+                    >
+                      {membership.contact?.name || `Contact #${membership.contactId}`}
+                    </Typography>                  
                     <Chip
                       label={getMembershipRole(membership)}
                       size="small"


### PR DESCRIPTION
# Summary of changes
- Modified the group membership list registry within the Group Details page to make member rows fully interactive.
- Added a `cursor: pointer` style and an `onClick` event listener to each row container, enabling direct routing to a person's profile page via `localRoutes.contacts`.

# How should this be tested?
1. Navigate to any Group Details profile view page.
2. Under the members list category registry, hover over a member row block and verify the background highlights.
3. Click anywhere on the row space and confirm it transitions directly into that specific person's profile page view.
4. Go back, click the management role alteration action button, and confirm the membership role shifts securely without executing routing redirections.

# Notes for reviewers
- Leveraged `membership.contactId || membership.contact?.id` fallback references to guarantee consistent destination calculations even under partially loaded relationship streams.

# Out of scope
- Tweaking global mobile viewport layout spacing frameworks inside general group cards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memberships in the “People in this Group” list are now clickable and open the associated contact’s details.
  * Added hover feedback and a pointer cursor to make interactive rows more apparent.
* **Style**
  * Updated contact name presentation while preserving the fallback display for contacts without names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->