### PR TITLE
Feat/contact chips group navigation

### DIFF
--- a/src/modules/contacts/ContactDetail.tsx
+++ b/src/modules/contacts/ContactDetail.tsx
@@ -292,6 +292,8 @@ const ContactDetail = () => {
                         label={gm.group.name}
                         color="primary"
                         size="medium"
+                        clickable 
+                        onClick={() => navigate(`${localRoutes.groups}/${gm.group.id}`)} 
                       />
                     ),
                 )}

--- a/src/modules/groups/GroupDetails.tsx
+++ b/src/modules/groups/GroupDetails.tsx
@@ -754,9 +754,11 @@ const GroupDetails = () => {
                   flexDirection={{ xs: 'column', sm: 'row' }}
                   gap={2}
                   p={1.5}
-                  sx={{
+                  sx={{                    
                     bgcolor: 'action.hover',
                     borderRadius: 1,
+                    cursor: 'pointer',
+                    '&:hover': { bgcolor: 'action.selected' }, 
                   }}
                 >
                   <Box
@@ -767,11 +769,18 @@ const GroupDetails = () => {
                     flexGrow={1}
                     width={{ xs: '100%', sm: 'auto' }}
                     minWidth={0}
+                    onClick={() => navigate(`${localRoutes.contacts}/${membership.contactId || membership.contact?.id}`)}
                   >
-                    <Typography variant="body2" noWrap sx={{ minWidth: 0 }}>
-                      {membership.contact?.name ||
-                        `Contact #${membership.contactId}`}
-                    </Typography>
+                    <Typography 
+                      variant="body2" 
+                      noWrap 
+                      sx={{ 
+                        minWidth: 0,
+                        fontWeight: 500,
+                      }}
+                    >
+                      {membership.contact?.name || `Contact #${membership.contactId}`}
+                    </Typography>                  
                     <Chip
                       label={getMembershipRole(membership)}
                       size="small"


### PR DESCRIPTION
# Summary of changes
- Transformed static group badge elements into interactive entry anchors inside the Contact Profile layout grid.
- Appended the native `clickable` boolean trigger attribute to the Material-UI `<Chip>` loops to hook up ripple animation cues and system navigation mouse indicators.
- Injected an active `onClick` transition listener mapping directly to destination views using `localRoutes.groups`.

# How should this be tested?
1. Access a designated Contact details profile view.
2. Locate the linked group membership tag collection chips.
3. Hover over any specific Group Chip and verify the layout pointer indicators alter dynamically.
4. Click the target chip indicator and confirm that the web browser seamlessly shifts straight to the matching Group's core detail summary page node.

# Notes for reviewers
- The UX changes align identically with layout patterns used for structural folder tree navigators elsewhere across the system UI workspace.

# Out of scope
- Restructuring database entity array structures or alter parameters on background group connection services.
