### PR TITLE
Feat/group search same location

### DIFF
--- a/src/modules/contacts/ContactDetail.tsx
+++ b/src/modules/contacts/ContactDetail.tsx
@@ -292,6 +292,10 @@ const ContactDetail = () => {
                         label={gm.group.name}
                         color="primary"
                         size="medium"
+                        clickable
+                        onClick={() =>
+                          navigate(`${localRoutes.groups}/${gm.group!.id}`)
+                        }
                       />
                     ),
                 )}

--- a/src/modules/tasks/UpdateStatusDialog.tsx
+++ b/src/modules/tasks/UpdateStatusDialog.tsx
@@ -136,7 +136,9 @@ export default function UpdateStatusDialog({
       const purpose =
         s === TaskStatus.ATTENDED_FELLOWSHIP ? 'fellowship' : 'serving_team';
       ajax
-        .get(`${remoteRoutes.groups}`, { params: { purpose } })
+        .get(`${remoteRoutes.groups}`, {
+          params: { purpose, sameLocation: true },
+        })
         .then((r) => {
           const list = Array.isArray(r.data) ? r.data : r.data?.data ?? [];
           setGroups(list);


### PR DESCRIPTION
- The groups fetch now sends `sameLocation: true`, so staff updating a task see all fellowship/serving-team groups at the contact's location, even ones they don't lead or belong to.

# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation from group membership chips in contact details.
  * Updated task status workflows to show groups from the same location when selecting fellowship or serving-team statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->