### PR TITLE
fix: improve dark mode visibility and restrict negative numeric input

### DIFF
--- a/src/modules/login/Login.tsx
+++ b/src/modules/login/Login.tsx
@@ -237,8 +237,6 @@ const Login = () => {
               disabled={loading}
               sx={{
                 py: 1.5,
-                backgroundColor: '#1a2332',
-                '&:hover': { backgroundColor: '#2d4059' },
                 textTransform: 'none',
                 fontSize: '1rem',
                 mb: 2,

--- a/src/modules/login/SignUp.tsx
+++ b/src/modules/login/SignUp.tsx
@@ -587,8 +587,6 @@ const SignUp = () => {
               disabled={isSubmitting}
               sx={{
                 py: 1.5,
-                backgroundColor: '#1a2332',
-                '&:hover': { backgroundColor: '#2d4059' },
                 textTransform: 'none',
                 fontSize: '1rem',
                 mb: 2,

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -568,8 +568,17 @@ const ReportSubmissionForm = () => {
     reportFields.forEach((field) => {
       if (!field.required) return;
       const value = formData[field.name];
-      const isEmpty =
-        field.type === 'checkbox' ||
+      const hasValue = value !== undefined && value !== null && value !== '';
+      if (
+        field.type === 'number' &&
+        hasValue &&
+        (!Number.isFinite(Number(value)) || Number(value) < 0)
+      ) {
+        errors[field.name] = `${field.label || field.name} must be 0 or greater`;
+        return;
+      }
+      if (!field.required) return;
+      const isEmpty =        field.type === 'checkbox' ||
         (field.type === 'select' && isDynamicMemberField(field))
           ? !Array.isArray(value) || value.length === 0
           : value === undefined || value === null || value === '';
@@ -920,6 +929,13 @@ const ReportSubmissionForm = () => {
             required={field.required}
             value={value}
             onChange={(e) => handleChange(field.name, e.target.value)}
+            // Blocks the minus key from being pressed
+            onKeyDown={(e) => {
+              if (e.key === '-' || e.code === 'Minus') {
+                e.preventDefault();
+              }
+            }}
+            inputProps={{ min: 0}}
             error={hasError}
             helperText={validationErrors[field.name]}
           />

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -566,7 +566,6 @@ const ReportSubmissionForm = () => {
     const errors: Record<string, string> = {};
     let hiddenFieldMissing = false;
     reportFields.forEach((field) => {
-      if (!field.required) return;
       const value = formData[field.name];
       const hasValue = value !== undefined && value !== null && value !== '';
       if (

--- a/src/theme-wh/customizations/feedback.tsx
+++ b/src/theme-wh/customizations/feedback.tsx
@@ -78,9 +78,9 @@ export const feedbackCustomizations: Components<Theme> = {
           color: gray[100],
         }),
       }),
-      circle: () => ({
+      circle:{
         strokeLinecap: 'round',
-      }),
+      },
     },
   },
 };

--- a/src/theme-wh/customizations/feedback.tsx
+++ b/src/theme-wh/customizations/feedback.tsx
@@ -70,4 +70,17 @@ export const feedbackCustomizations: Components<Theme> = {
       }),
     },
   },
+  MuiCircularProgress: {
+    styleOverrides: {
+      root: ({ theme }) => ({
+        color: gray[700],
+        ...theme.applyStyles('dark', {
+          color: gray[100],
+        }),
+      }),
+      circle: () => ({
+        strokeLinecap: 'round',
+      }),
+    },
+  },
 };


### PR DESCRIPTION
## What
Fixes 3 UI issues: loader contrast in dark mode, negative values in numeric report fields, and button hover states in dark mode.

## Changes

**1. Loader visibility (dark mode)**
- Added a global `MuiCircularProgress` override in the theme config
  (`feedbackCustomizations.ts`) instead of per-instance `sx` props.
- Uses `theme.applyStyles('dark', ...)` to match the existing pattern
  used by `MuiAlert` / `MuiLinearProgress` in the same file.

**2. Negative values in numeric fields**
Added `inputProps={{ min: 0 }}`: Restricts the native browser UI elements and arrow keys from stepping below zero.
Added `onKeyDown` Interception: Listens for the minus key `(- / Minus)` and calls e.preventDefault() to instantly block users from typing negative signs.

**3. Sign In/Sign Up button hover states**
- Removed the hardcoded background colors that was used initially, allow it to take up dark mood hovers.

## Testing
- Manually tested loader in both light/dark theme toggle.
- Manually tested numeric field: typing `-`, pasting `-5`, and
  scrolling on the field no longer produces a negative value.
- Manually tested button hover/active/disabled states in dark mode.

## Notes for reviewers
Scope is intentionally limited to these 3 items — no unrelated
refactors or file moves included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report form validation to reject negative and non-finite numbers.
  * Numeric fields now prevent negative input and enforce a minimum value of zero.
* **Style**
  * Updated sign-in and account creation buttons to use consistent default styling.
  * Improved loading indicator visibility across light and dark themes, including rounded progress strokes.
  * Preserved existing loading states, disabled-button behavior, and form submission feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->