### PR TITLE
feat: display weekly MC attendance total on reports page

### DIFF
--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -123,6 +123,8 @@ const Reports = () => {
   useEffect(() => {
     if (activeTab === null) return;
 
+     let cancelled = false;
+
     // Check cache
     const cached = tabCache[activeTab];
     if (cached && cached.dateRange === dateRange) {
@@ -133,17 +135,23 @@ const Reports = () => {
     }
 
     setLoadingSubmissions(true);
+    setSummary(null);
+
     const { from, to } = getDateRange();
     const url = `${remoteRoutes.reports}/submissions/mygroups?reportId=${activeTab}&from=${from}&to=${to}&limit=20&offset=0`;
 
     get(
       url,
       (response: SubmissionsResponse) => {
+        if (cancelled) return;
+
         const data = response?.submissions || [];
         const cols = response?.columns || [];
+
         setSubmissions(data);
         setColumns(cols);
         setSummary(response?.summary || null);
+
         setTabCache((prev) => ({
           ...prev,
           [activeTab]: {
@@ -153,16 +161,23 @@ const Reports = () => {
             summary: response?.summary || null
           },
         }));
+
         setLoadingSubmissions(false);
+
       },
       (error: any) => {
+        if (cancelled) return;
         console.error('Failed to fetch submissions:', error);
         toast.error('Failed to load submissions');
         setSubmissions([]);
         setColumns([]);
         setLoadingSubmissions(false);
+        setSummary(null);
       },
     );
+    return () => {
+      cancelled = true;
+    };
   }, [activeTab, dateRange, getDateRange]);
 
   // Invalidate cache when date range changes

--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -39,10 +39,15 @@ interface PaginationInfo {
   offset: number;
 }
 
+interface ReportSummary {
+  weeklyAttendanceTotal: number;
+}
+
 interface SubmissionsResponse {
   submissions: Record<string, any>[];
   columns: Column[];
   pagination: PaginationInfo;
+  summary?: ReportSummary;
 }
 
 interface SubmissionDetails {
@@ -59,6 +64,7 @@ interface TabCache {
   data: Record<string, any>[];
   columns: Column[];
   dateRange: DateRange;
+  summary?: ReportSummary | null;
 }
 
 const Reports = () => {
@@ -72,6 +78,7 @@ const Reports = () => {
   const [loadingSubmissions, setLoadingSubmissions] = useState(false);
   const [submissions, setSubmissions] = useState<Record<string, any>[]>([]);
   const [columns, setColumns] = useState<Column[]>([]);
+  const [summary, setSummary] = useState<ReportSummary | null>(null);
   const [tabCache, setTabCache] = useState<Record<number, TabCache>>({});
 
   // Modal state
@@ -121,6 +128,7 @@ const Reports = () => {
     if (cached && cached.dateRange === dateRange) {
       setSubmissions(cached.data);
       setColumns(cached.columns);
+      setSummary(cached.summary || null);
       return;
     }
 
@@ -135,9 +143,15 @@ const Reports = () => {
         const cols = response?.columns || [];
         setSubmissions(data);
         setColumns(cols);
+        setSummary(response?.summary || null);
         setTabCache((prev) => ({
           ...prev,
-          [activeTab]: { data, columns: cols, dateRange },
+          [activeTab]: {
+            data,
+            columns: cols,
+            dateRange,
+            summary: response?.summary || null
+          },
         }));
         setLoadingSubmissions(false);
       },
@@ -312,6 +326,15 @@ const Reports = () => {
           ))}
         </Tabs>
       )}
+      
+      {/* Weekly Attendance Summary */}
+      {summary && activeReportName === 'MC Attendance Report' && (
+        <Box mb={2}>
+          <Typography variant="h6">
+            Weekly Attendance Total: {summary.weeklyAttendanceTotal}
+            </Typography>
+            </Box>
+          )}
 
       {/* Table */}
       <ReportsTable

--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -341,15 +341,37 @@ const Reports = () => {
           ))}
         </Tabs>
       )}
-      
+
       {/* Weekly Attendance Summary */}
       {summary && activeReportName === 'MC Attendance Report' && (
-        <Box mb={2}>
-          <Typography variant="h6">
-            Weekly Attendance Total: {summary.weeklyAttendanceTotal}
-            </Typography>
-            </Box>
-          )}
+        <Box
+          sx={{
+            mb: 2,
+            p: 2,
+            borderRadius: 2,
+            border: '1px solid',
+            borderColor: 'divider',
+            bgcolor: 'background.paper',
+            display: 'inline-flex',
+            textAlign: 'center',
+            flexDirection: 'column',
+            minWidth: 220,
+          }}
+        >
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ textTransform: 'capitalize', letterSpacing: 1 }}
+          >
+            Weekly MC Attendance Total
+          </Typography>
+
+          <Typography variant="h3" fontWeight={600}>
+            {summary.weeklyAttendanceTotal}
+          </Typography>
+
+        </Box>
+      )}
 
       {/* Table */}
       <ReportsTable


### PR DESCRIPTION
# Ticket No
- N/A

## Summary of changes
- Added support for displaying the weekly MC attendance total from the reports summary response.
- Updated the Reports page to display the **Weekly Attendance Total** for the **MC Attendance Report**.
- Extended frontend types and state handling to consume the summary data returned by the existing reports submissions endpoint.
- Updated report tab caching to preserve summary data when loading cached report results.

## How should this be tested?
1. Navigate to the **Reports** page.
2. Open the **MC Attendance Report** tab.
3. Verify that the **Weekly Attendance Total** summary is displayed above the submissions table.
4. Confirm that the displayed total matches the sum of the attendance values from the visible MC attendance submissions.
5. Switch between report tabs and return to the **MC Attendance Report** to confirm the cached summary data remains available.

## Testing Done
- Verified existing frontend tests pass:
  - `npm test`
- Verified production build succeeds:
  - `npm run build`

## Notes for reviewers
- The weekly attendance summary is only displayed for the **MC Attendance Report**.
- The summary is handled as report metadata rather than modifying submission table data.

## Out of scope
- Redesigning the Reports page UI.
- Adding additional report summary metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a “Weekly Attendance Total” summary to the MC Attendance Report when available.
- Summary information is restored when switching between report tabs or date ranges.

## Bug Fixes
- Prevented outdated or cancelled report requests from displaying incorrect attendance summaries.
- Cleared unavailable summary information when reports are refreshed or fail to load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->