### PR TITLE
fix(contacts): open edit form in modal from row menu

### DIFF
--- a/src/modules/contacts/Contacts.tsx
+++ b/src/modules/contacts/Contacts.tsx
@@ -26,6 +26,7 @@ import {
   Stack,
   Chip,
   Divider,
+  Alert,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
@@ -85,6 +86,8 @@ const Contacts = () => {
 
   const [createDialog, setCreateDialog] = useState(false);
   const [uploadDialog, setUploadDialog] = useState(false);
+  const [editDialog, setEditDialog] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
   const [filter, setFilter] = useState<ContactFilter>({
     limit: CONTACT_FETCH_LIMIT,
     skip: 0,
@@ -204,6 +207,20 @@ const Contacts = () => {
       navigate(`${localRoutes.contacts}/${selectedContact.id}`);
     }
     handleMenuClose();
+  };
+
+  const handleEdit = () => {
+    setEditError(null);
+    setEditDialog(true);
+    setAnchorEl(null);
+  };
+
+  const handleEditSave = () => {
+    setEditError(null);
+    setEditDialog(false);
+    setSelectedContact(null);
+    // Refresh contacts list; keep same pagination
+    setFilter((prev) => ({ ...prev }));
   };
 
   const getInitials = (name: string) => {
@@ -569,7 +586,7 @@ const Contacts = () => {
         onClose={handleMenuClose}
       >
         <MenuItem onClick={handleViewDetails}>View Details</MenuItem>
-        <MenuItem onClick={handleViewDetails}>Edit</MenuItem>
+        <MenuItem onClick={handleEdit}>Edit</MenuItem>
       </Menu>
 
       {/* New Contact Dialog */}
@@ -590,6 +607,39 @@ const Contacts = () => {
               setFilter((prev) => ({ ...prev }));
             }}
             onCancel={() => setCreateDialog(false)}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Contact Dialog */}
+      <Dialog
+        open={editDialog}
+        onClose={() => {
+          setEditError(null);
+          setEditDialog(false);
+          setSelectedContact(null);
+        }}
+        maxWidth="md"
+        fullWidth
+        fullScreen={isMobile}
+        scroll="paper"
+      >
+        <DialogTitle>Edit Contact</DialogTitle>
+        <DialogContent dividers={isMobile}>
+          {editError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {editError}
+            </Alert>
+          )}
+          <ContactForm
+            contactId={selectedContact?.id}
+            onSave={handleEditSave}
+            onCancel={() => {
+              setEditError(null);
+              setEditDialog(false);
+              setSelectedContact(null);
+            }}
+            onError={(message) => setEditError(message || null)}
           />
         </DialogContent>
       </Dialog>

--- a/src/modules/contacts/Contacts.tsx
+++ b/src/modules/contacts/Contacts.tsx
@@ -208,7 +208,11 @@ const Contacts = () => {
     }
     handleMenuClose();
   };
-
+  const handleEditClose = () => {
+    setEditError(null);
+    setEditDialog(false);
+    setSelectedContact(null);
+  }
   const handleEdit = () => {
     setEditError(null);
     setEditDialog(true);
@@ -216,9 +220,7 @@ const Contacts = () => {
   };
 
   const handleEditSave = () => {
-    setEditError(null);
-    setEditDialog(false);
-    setSelectedContact(null);
+    handleEditClose()
     // Refresh contacts list; keep same pagination
     setFilter((prev) => ({ ...prev }));
   };
@@ -614,11 +616,7 @@ const Contacts = () => {
       {/* Edit Contact Dialog */}
       <Dialog
         open={editDialog}
-        onClose={() => {
-          setEditError(null);
-          setEditDialog(false);
-          setSelectedContact(null);
-        }}
+        onClose={handleEditClose}
         maxWidth="md"
         fullWidth
         fullScreen={isMobile}
@@ -634,11 +632,7 @@ const Contacts = () => {
           <ContactForm
             contactId={selectedContact?.id}
             onSave={handleEditSave}
-            onCancel={() => {
-              setEditError(null);
-              setEditDialog(false);
-              setSelectedContact(null);
-            }}
+            onCancel={handleEditClose}
             onError={(message) => setEditError(message || null)}
           />
         </DialogContent>


### PR DESCRIPTION
## What
Clicking "Edit" from the row action menu on the Contacts list now opens the `ContactForm` directly in a modal, instead of navigating to the contact detail page first and requiring a second click there.

## Why
`ContactDetail` already supports editing a contact in-place via a modal (Edit button → `Dialog` → `ContactForm`). The Contacts list's "Edit" action was a dead shortcut to the same two-step flow — this brings it in line with that existing, expected pattern and removes the extra hop.

## Changes
- `Contacts.tsx`
  - New `editDialog` / `editError` state
  - New `handleEdit` (opens modal, keeps menu's `selectedContact`)
  - New `handleEditSave` (closes modal, clears state, refreshes list)
  - "Edit" menu item now calls `handleEdit` instead of `handleViewDetails`
  - "View Details" menu item behavior is unchanged (still navigates)
  - Added Edit dialog block, structurally identical to the one in
    `ContactDetail.tsx` (title, error `Alert`, `ContactForm` with
    `contactId`, `onSave`, `onCancel`, `onError`)

## Not in scope
- No changes to `ContactForm`, `ContactDetail`, or the API layer
- No changes to the "View Details" navigation flow

## Testing
- [ ] Click row menu → Edit → modal opens with the correct contact loaded
- [ ] Save in modal → list refreshes, modal closes
- [ ] Cancel in modal → modal closes, no stale state on next open
- [ ] Click row menu → View Details → still navigates to detail page
- [ ] Mobile viewport: modal still opens `fullScreen` as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to edit contacts directly from the contacts page.
  * Introduced an “Edit Contact” dialog with save and cancel actions.
  * Display edit errors in-app when saving contact changes fails.
  * Refreshes the contacts list after a successful edit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->