### PR TITLE
fix(ui): auto-close schedule dialog on save, fix reports config dark …

### DIFF
--- a/src/modules/admin/reports/ReportConfiguration.tsx
+++ b/src/modules/admin/reports/ReportConfiguration.tsx
@@ -274,7 +274,8 @@ const ReportConfiguration = () => {
                   color: isInactive ? 'text.secondary' : 'text.primary',
                 },
               }}
-            >              <TableCell sx={{ fontWeight: 'bold' }}>Name</TableCell>
+            >              
+            <TableCell sx={{ fontWeight: 'bold' }}>Name</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>Category</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>Frequency</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>View Type</TableCell>

--- a/src/modules/admin/reports/ReportConfiguration.tsx
+++ b/src/modules/admin/reports/ReportConfiguration.tsx
@@ -263,14 +263,18 @@ const ReportConfiguration = () => {
       <TableContainer
         component={Paper}
         variant="outlined"
-        sx={{
-          backgroundColor: isInactive ? 'grey.50' : '#fff',
-        }}
+        sx={{backgroundColor: isInactive ? 'action.hover' : 'background.paper' }}
       >
         <Table size="small">
           <TableHead>
-            <TableRow sx={{ backgroundColor: isInactive ? 'grey.100' : 'grey.50' }}>
-              <TableCell sx={{ fontWeight: 'bold' }}>Name</TableCell>
+            <TableRow
+              sx={{
+                backgroundColor: isInactive ? 'action.selected' : 'action.hover',
+                '& .MuiTableCell-root': {
+                  color: isInactive ? 'text.secondary' : 'text.primary',
+                },
+              }}
+            >              <TableCell sx={{ fontWeight: 'bold' }}>Name</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>Category</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>Frequency</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>View Type</TableCell>
@@ -382,7 +386,7 @@ const ReportConfiguration = () => {
               cursor: 'pointer',
               py: 1,
               px: 2,
-              backgroundColor: 'grey.100',
+              backgroundColor: 'action.selected',
               borderRadius: 1,
               mb: showInactive ? 2 : 0,
             }}

--- a/src/modules/attendance/schedules/ScheduleFormDialog.tsx
+++ b/src/modules/attendance/schedules/ScheduleFormDialog.tsx
@@ -150,7 +150,8 @@ export default function ScheduleFormDialog({ open, onClose, editing }: Props) {
     onSuccess: () => {
       toast.success(editing ? 'Schedule updated.' : 'Schedule created.');
       queryClient.invalidateQueries({ queryKey: ['schedules'] });
-      handleClose();
+      onClose();
+      formik.resetForm({ values: defaultValues });
     },
     onError: (error: any) => {
       const message =

--- a/src/modules/tasks/TaskCard.tsx
+++ b/src/modules/tasks/TaskCard.tsx
@@ -112,7 +112,7 @@ export default function TaskCard({ task, onOpen, showContact = false }: Props) {
             to={`${localRoutes.contacts}/${task.contact.id}`}
             onClick={(e) => e.stopPropagation()}
             sx={{
-              color: 'primary.main',
+              color: 'text.primary',
               textDecoration: 'none',
               display: 'block',
               mb: 0.5,


### PR DESCRIPTION
## Ticket No - Ticket: 
N/A — internal bug fix + UI polish

### Improvements Implemented
- **ScheduleFormDialog**: on successful create/update, the dialog now closes and resets the form directly inside `mutation.onSuccess`, instead of calling `handleClose` (which guards on `!mutation.isPending`). Previously, the dialog would sometimes fail to close automatically after a successful save, even though the toast and data update happened correctly — requiring the user to click "Close" manually. `handleClose`'s guard is preserved as-is for the manual Close button and dialog backdrop dismissal, where blocking a close mid-save is still the correct behavior.
- **ReportConfiguration**: replaced hardcoded light-mode colors (`'#fff'`, `'grey.50'`, `'grey.100'`) on the reports table with theme-aware MUI tokens (`background.paper`, `action.hover`, `action.selected`), and added explicit text color handling for inactive rows. Both the active and inactive reports tables now render correctly against a dark theme instead of showing a bright, hardcoded light background.

### Notes for Reviewers
- The dialog-close fix is scoped to the success path only — no changes to error handling, validation, or the manual Close/backdrop behavior.
- The dark mode fix is purely visual (`sx` prop changes); no logic, data fetching, or table structure was touched.

### How Has This Been Tested?
- Created and edited a service schedule; confirmed the dialog now closes automatically on success without needing a manual click, and that the toast still fires correctly.
- Confirmed the manual "Close" button still respects the in-flight-save guard (doesn't close while `mutation.isPending` is true).
- Toggled system/browser dark mode and visually verified the Active and Inactive report tables (including the collapsed/expanded inactive section) render with correct contrast and no hardcoded white/grey backgrounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Schedule dialogs now close reliably after saving, and the form resets back to default values on success.
  - Report tables and the inactive reports section now use theme-driven colors for more consistent styling.
  - Task contact links have updated text color for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->