### PR TITLE
feat(notifications): add in-app notifications with real-time push

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.30.4",
         "react-toastify": "^11.0.5",
+        "socket.io-client": "^4.8.3",
         "uuid": "^13.0.1",
         "yup": "^1.7.1"
       },
@@ -1021,24 +1022,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1055,24 +1038,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1087,24 +1052,6 @@
       ],
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -2709,6 +2656,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -4346,6 +4299,28 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.21.0",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
@@ -6892,6 +6867,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -7487,420 +7490,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
@@ -7926,50 +7515,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/vitest/node_modules/vite": {
@@ -8145,6 +7690,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -8160,6 +7726,14 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.30.4",
     "react-toastify": "^11.0.5",
+    "socket.io-client": "^4.8.3",
     "uuid": "^13.0.1",
     "yup": "^1.7.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ import ManageNotifications from './modules/admin/notifications/ManageNotificatio
 import CheckInScreen from './modules/attendance/CheckInScreen';
 import ServiceSchedules from './modules/attendance/schedules/ServiceSchedules';
 import AttendanceHistory from './modules/attendance/history/AttendanceHistory';
+import NotificationsPage from './modules/notifications/Notifications.tsx';
 
 const Splash = () => (
   <div
@@ -296,6 +297,9 @@ function App() {
                 attendanceViewCapabilities,
               )}
             />
+            <Route 
+              path={localRoutes.notificationMessages} 
+              element={<NotificationsPage />} />
             <Route path="/" element={<Dashboard />} />
             {/* We'll add more routes here as we migrate modules */}
             <Route path="*" element={<Dashboard />} />

--- a/src/components/layout-v2/Header.tsx
+++ b/src/components/layout-v2/Header.tsx
@@ -9,17 +9,18 @@ import MenuItem from '@mui/material/MenuItem';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
-import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import LocationOnRoundedIcon from '@mui/icons-material/LocationOnRounded';
 import NavbarBreadcrumbs from './NavbarBreadcrumbs';
-import MenuButton from './MenuButton';
 import ColorModeIconDropdown from './ColorModeIconDropdown';
 import { useSelector, useDispatch } from 'react-redux';
 import type { RootState } from '../../data/store';
 import { logout } from '../../data/coreSlice';
 import { get } from '../../utils/ajax';
 import { remoteRoutes } from '../../data/constants';
+import NotificationBell from '../../modules/notifications/NotificationBell';
+import { useAuthToken } from '../../hooks/useAuthToken';
+import { useNotificationSocket } from '../../data/useNotificationSocket';
 
 interface LocationGroup {
   id: number;
@@ -30,6 +31,8 @@ interface LocationGroup {
 export default function Header() {
   const dispatch = useDispatch();
   const { user } = useSelector((state: RootState) => state.core);
+  const token = useAuthToken();
+  useNotificationSocket(token);
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [userLocations, setUserLocations] = useState<LocationGroup[]>([]);
@@ -94,9 +97,7 @@ export default function Header() {
         >
           <NavbarBreadcrumbs />
           <Stack direction="row" sx={{ gap: 1, alignItems: 'center' }}>
-            <MenuButton showBadge aria-label="Open notifications">
-              <NotificationsRoundedIcon />
-            </MenuButton>
+            <NotificationBell />
             <ColorModeIconDropdown />
             {/* User Profile Menu */}
             <IconButton

--- a/src/components/layout-v2/MenuContent.tsx
+++ b/src/components/layout-v2/MenuContent.tsx
@@ -194,6 +194,11 @@ const navItems: NavItem[] = [
       },
     ],
   },
+  {
+    name: 'Notifications',
+    icon: <SmsRoundedIcon />,
+    path: localRoutes.notificationMessages,
+  },
 ];
 
 interface MenuContentProps {

--- a/src/components/layout-v2/MenuContent.tsx
+++ b/src/components/layout-v2/MenuContent.tsx
@@ -83,6 +83,11 @@ const navItems: NavItem[] = [
     ],
   },
   {
+    name: 'Notifications',
+    icon: <SmsRoundedIcon />,
+    path: localRoutes.notificationMessages,
+  },
+  {
     name: 'Attendance',
     icon: <HowToRegRoundedIcon />,
     path: localRoutes.attendance,
@@ -193,11 +198,6 @@ const navItems: NavItem[] = [
         path: localRoutes.financialReports,
       },
     ],
-  },
-  {
-    name: 'Notifications',
-    icon: <SmsRoundedIcon />,
-    path: localRoutes.notificationMessages,
   },
 ];
 

--- a/src/components/layout-v2/SideMenuMobile.tsx
+++ b/src/components/layout-v2/SideMenuMobile.tsx
@@ -5,7 +5,6 @@ import Drawer, { drawerClasses } from '@mui/material/Drawer';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
-import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
 import CloseRoundedIcon from '@mui/icons-material/CloseRounded';
 import { useDispatch } from 'react-redux';
 import { useSelector } from 'react-redux';
@@ -14,6 +13,7 @@ import { logout } from '../../data/coreSlice';
 import MenuButton from './MenuButton';
 import MenuContent from './MenuContent';
 import SidebarHelpButton from './SidebarHelpButton';
+import NotificationBell from '../../modules/notifications/NotificationBell';
 
 interface SideMenuMobileProps {
   open: boolean | undefined;
@@ -106,7 +106,7 @@ export default function SideMenuMobile({
             </Stack>
           </Stack>
           <MenuButton showBadge>
-            <NotificationsRoundedIcon />
+            <NotificationBell/>
           </MenuButton>
           <MenuButton aria-label="Close menu" onClick={toggleDrawer(false)}>
             <CloseRoundedIcon />

--- a/src/components/layout-v2/SideMenuMobile.tsx
+++ b/src/components/layout-v2/SideMenuMobile.tsx
@@ -105,9 +105,7 @@ export default function SideMenuMobile({
               </Typography>
             </Stack>
           </Stack>
-          <MenuButton showBadge>
-            <NotificationBell/>
-          </MenuButton>
+          <NotificationBell onCloseMenu={toggleDrawer(false)} />          
           <MenuButton aria-label="Close menu" onClick={toggleDrawer(false)}>
             <CloseRoundedIcon />
           </MenuButton>

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -108,6 +108,7 @@ export const localRoutes = {
 
   // Notifications
   notifications: '/admin/notifications',
+  notificationMessages: '/notifications',
 
   // Tasks
   tasks: '/tasks',
@@ -194,6 +195,7 @@ export const remoteRoutes = {
 
   // Notifications
   notificationSettings: `${apiBaseUrl}/api/notifications/settings`,
+  notificationMessages: `${apiBaseUrl}/api/notifications`,
 
   // Tasks
   tasks: `${apiBaseUrl}/api/tasks`,

--- a/src/data/useNotificationSocket.ts
+++ b/src/data/useNotificationSocket.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import { notificationKeys } from '../modules/notifications/hooks';
+
+import { apiBaseUrl } from './constants';
+
+const SOCKET_URL = apiBaseUrl;
+
+export function useNotificationSocket(token: string | null) {
+  const qc = useQueryClient();
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+
+    const socket = io(`${SOCKET_URL}/notifications`, {
+      auth: { token },
+      transports: ['websocket'],
+    });    
+    socketRef.current = socket;
+
+    socket.on('notification:new', (notification) => {
+      // Bump unread count + prepend to the cached list without a full refetch
+      qc.setQueryData(notificationKeys.unreadCount, (old: number = 0) => old + 1);
+      qc.invalidateQueries({ queryKey: notificationKeys.list });
+
+      toast.info(notification.title, { autoClose: 5000 });
+    });
+
+    socket.on('connect_error', (err) => {
+      console.error('Notification socket connection error:', err.message);
+    });
+
+    return () => {
+      socket.disconnect();
+      if (socketRef.current === socket) {
+        socketRef.current = null;
+      }
+    };
+  }, [token, qc]);
+
+  return socketRef;
+}

--- a/src/data/useNotificationSocket.ts
+++ b/src/data/useNotificationSocket.ts
@@ -6,7 +6,7 @@ import { notificationKeys } from '../modules/notifications/hooks';
 
 import { apiBaseUrl } from './constants';
 
-const SOCKET_URL = apiBaseUrl;
+const NOTIFICATIONS_SOCKET_URL = new URL('/notifications', apiBaseUrl).toString();
 
 export function useNotificationSocket(token: string | null) {
   const qc = useQueryClient();
@@ -15,7 +15,7 @@ export function useNotificationSocket(token: string | null) {
   useEffect(() => {
     if (!token) return;
 
-    const socket = io(`${SOCKET_URL}/notifications`, {
+    const socket = io(NOTIFICATIONS_SOCKET_URL, {
       auth: { token },
       transports: ['websocket'],
     });    

--- a/src/hooks/useAuthToken.ts
+++ b/src/hooks/useAuthToken.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../data/store';
+import { AUTH_TOKEN_KEY } from '../data/constants';
+import { isTokenExpired } from '../utils/ajax';
+
+export function useAuthToken(): string | null {
+  const { user } = useSelector((state: RootState) => state.core);
+
+  return useMemo(() => {
+    if (!user) return null;
+    const token = localStorage.getItem(AUTH_TOKEN_KEY);
+    if (!token || isTokenExpired(token)) return null;
+    return token;
+  }, [user]);
+}

--- a/src/modules/notifications/NotificationBell.tsx
+++ b/src/modules/notifications/NotificationBell.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react';
+import {
+  Badge,
+  IconButton,
+  Menu,
+  MenuItem,
+  Typography,
+  Box,
+  Divider,
+  Button,
+  CircularProgress,
+} from '@mui/material';
+import NotificationsRoundedIcon from '@mui/icons-material/NotificationsRounded';
+import DoneAllIcon from '@mui/icons-material/DoneAll';
+import { useNavigate } from 'react-router-dom';
+import dayjs from 'dayjs';
+import {
+  useNotifications,
+  useUnreadCount,
+  useMarkNotificationRead,
+  useMarkAllNotificationsRead,
+} from './hooks';
+import type { Notification } from '../../utils/types';
+import { localRoutes } from '../../data/constants';
+
+export default function NotificationBell() {
+  const navigate = useNavigate();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const { data: unreadCount = 0 } = useUnreadCount();
+  const { data, isLoading } = useNotifications(1, 8); // preview: latest 8
+  const markRead = useMarkNotificationRead();
+  const markAllRead = useMarkAllNotificationsRead();
+
+  const handleOpen = (e: React.MouseEvent<HTMLElement>) => setAnchorEl(e.currentTarget);
+  const handleClose = () => setAnchorEl(null);
+
+  const handleItemClick = (n: Notification) => {
+    if (!n.isRead) markRead.mutate(n.id);
+    handleClose();
+    if (n.link) navigate(n.link);
+  };
+
+  const notifications = data?.data ?? [];
+
+  return (
+    <>
+      <IconButton onClick={handleOpen} aria-label="Open notifications" size="small">
+        <Badge badgeContent={unreadCount} color="error" max={99} >
+          <NotificationsRoundedIcon sx={{ fontSize: 24 }}/>
+        </Badge>
+      </IconButton>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        slotProps={{ paper: { sx: { width: 360, maxHeight: 480 } } }}
+      >
+        <Box sx={{display:"flex", justifyContent:"space-between", alignItems:"center", p:1}}>
+          <Typography variant="subtitle1"  sx={{ fontWeight: 600 }}>
+            Notifications
+          </Typography>
+          {unreadCount > 0 && (
+            <Button size="small" onClick={() => markAllRead.mutate()} sx={{display:"flex", alignItems:"center", p:1, gap:1}}>
+              <DoneAllIcon/>  Mark all read
+            </Button>
+          )}
+        </Box>
+        <Divider />
+
+        {isLoading ? (
+          <Box sx={{display:"flex", justifyContent:"space-between", py:3}}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : !notifications ? (
+          <Box sx={{textAlign:"center", py:3}}>
+            <Typography variant="body2" color="text.secondary">
+              Unable to load notifications at this time
+            </Typography>
+          </Box>
+        ) : notifications.length === 0 ? (
+          <Box sx={{textAlign:"center", py:3}}>
+            <Typography variant="body2" color="text.secondary">
+              No notifications yet
+            </Typography>
+          </Box>
+
+        ) : (
+          notifications.map((n) => (
+            <MenuItem
+              key={n.id}
+              onClick={() => handleItemClick(n)}
+              sx={{
+                whiteSpace: 'normal',
+                alignItems: 'flex-start',
+                py: 1.25,
+                bgcolor: n.isRead ? 'transparent' : 'action.hover',
+              }}
+            >
+              <Box sx={{width:"100%"}}>
+                <Box sx={{display:"flex", justifyContent:"space-between", alignItems:"center", width:"100%"}}>
+                  <Typography variant="body2" sx={{ fontWeight: n.isRead ? 400 : 600 }}>
+                    {n.title}
+                  </Typography>
+                  <Typography variant="caption" color="text.disabled">
+                    {dayjs(n.createdAt).fromNow()}
+                  </Typography>
+                </Box>
+                {n.body && (
+                  <Typography variant="caption" color="text.secondary" display="block">
+                    {n.body}
+                  </Typography>
+                )}
+              </Box>
+            </MenuItem>
+          ))
+        )}
+
+        <Divider />
+        <MenuItem
+          onClick={() => {
+            handleClose();
+            navigate(localRoutes.notificationMessages);
+          }}
+          sx={{ fontWeight: 600 }}
+        >
+          View all notifications
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/src/modules/notifications/NotificationBell.tsx
+++ b/src/modules/notifications/NotificationBell.tsx
@@ -29,7 +29,7 @@ export default function NotificationBell() {
   const open = Boolean(anchorEl);
 
   const { data: unreadCount = 0 } = useUnreadCount();
-  const { data, isLoading } = useNotifications(1, 8); // preview: latest 8
+  const { data, isLoading, isError } = useNotifications(1, 8); // preview: latest 8
   const markRead = useMarkNotificationRead();
   const markAllRead = useMarkAllNotificationsRead();
 
@@ -41,8 +41,6 @@ export default function NotificationBell() {
     handleClose();
     if (n.link) navigate(n.link);
   };
-
-  const { isError } = useNotifications(1, 20); 
   const notifications = data?.data ?? [];
 
   return (

--- a/src/modules/notifications/NotificationBell.tsx
+++ b/src/modules/notifications/NotificationBell.tsx
@@ -42,6 +42,7 @@ export default function NotificationBell() {
     if (n.link) navigate(n.link);
   };
 
+  const { isError } = useNotifications(1, 20); 
   const notifications = data?.data ?? [];
 
   return (
@@ -74,7 +75,7 @@ export default function NotificationBell() {
           <Box sx={{display:"flex", justifyContent:"space-between", py:3}}>
             <CircularProgress size={24} />
           </Box>
-        ) : !notifications ? (
+        ) : isError ? (
           <Box sx={{textAlign:"center", py:3}}>
             <Typography variant="body2" color="text.secondary">
               Unable to load notifications at this time

--- a/src/modules/notifications/NotificationBell.tsx
+++ b/src/modules/notifications/NotificationBell.tsx
@@ -23,7 +23,11 @@ import {
 import type { Notification } from '../../utils/types';
 import { localRoutes } from '../../data/constants';
 
-export default function NotificationBell() {
+interface NotificationBellProps {
+  onCloseMenu?: () => void;
+}
+
+export default function NotificationBell({ onCloseMenu }: NotificationBellProps) {
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
@@ -39,6 +43,7 @@ export default function NotificationBell() {
   const handleItemClick = (n: Notification) => {
     if (!n.isRead) markRead.mutate(n.id);
     handleClose();
+    if (onCloseMenu) onCloseMenu();
     if (n.link) navigate(n.link);
   };
   const notifications = data?.data ?? [];
@@ -55,7 +60,14 @@ export default function NotificationBell() {
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
-        slotProps={{ paper: { sx: { width: 360, maxHeight: 480 } } }}
+        slotProps={{ 
+          paper: { 
+            sx: { 
+              width: 'min(360px, calc(100vw - 16px))', // Prevents screen bleed on mobile
+              maxHeight: 480 
+            } 
+          } 
+        }}
       >
         <Box sx={{display:"flex", justifyContent:"space-between", alignItems:"center", p:1}}>
           <Typography variant="subtitle1"  sx={{ fontWeight: 600 }}>
@@ -70,7 +82,7 @@ export default function NotificationBell() {
         <Divider />
 
         {isLoading ? (
-          <Box sx={{display:"flex", justifyContent:"space-between", py:3}}>
+          <Box sx={{display:"flex", justifyContent:"center", py:3}}>
             <CircularProgress size={24} />
           </Box>
         ) : isError ? (
@@ -121,9 +133,10 @@ export default function NotificationBell() {
         <MenuItem
           onClick={() => {
             handleClose();
+            if (onCloseMenu) onCloseMenu();
             navigate(localRoutes.notificationMessages);
           }}
-          sx={{ fontWeight: 600 }}
+          sx={{ fontWeight: 600}}
         >
           View all notifications
         </MenuItem>

--- a/src/modules/notifications/Notifications.tsx
+++ b/src/modules/notifications/Notifications.tsx
@@ -27,6 +27,7 @@ export default function Notifications() {
   const markRead = useMarkNotificationRead();
   const markAllRead = useMarkAllNotificationsRead();
 
+  const { isError } = useNotifications(1, 20); 
   const notifications = data?.data ?? [];
   const total = data?.total ?? 0;
   const unreadCount = data?.unreadCount ?? 0;
@@ -58,11 +59,11 @@ export default function Notifications() {
         )}
       </Stack>
 
-        {isLoading ? (
+      {isLoading ? (
         <Box sx={{display:"flex", justifyContent:"center", py:3}}>
           <CircularProgress />
         </Box>
-      ) : !notifications ? (
+      ) : isError ? (
         <Box sx={{textAlign:"center", py:3}}>
           <Typography color="text.secondary">
             Unable to load notifications at this time

--- a/src/modules/notifications/Notifications.tsx
+++ b/src/modules/notifications/Notifications.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import {
+  Typography,
+  Box,
+  Stack,
+  Button,
+  CircularProgress,
+  TablePagination,
+  Divider,
+  ListItemButton,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import { useNavigate } from 'react-router-dom';
+import {
+  useNotifications,
+  useMarkNotificationRead,
+  useMarkAllNotificationsRead,
+} from './hooks';
+import type { Notification } from '../../utils/types';
+
+export default function Notifications() {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(0);
+  const rowsPerPage = 20;
+
+  const { data, isLoading } = useNotifications(page + 1, rowsPerPage);
+  const markRead = useMarkNotificationRead();
+  const markAllRead = useMarkAllNotificationsRead();
+
+  const notifications = data?.data ?? [];
+  const total = data?.total ?? 0;
+  const unreadCount = data?.unreadCount ?? 0;
+
+  const handleClick = (n: Notification) => {
+    if (!n.isRead) markRead.mutate(n.id);
+    if (n.link) navigate(n.link);
+  };
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      {/* Header */}
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        sx={{ mb: 3, justifyContent:"space-between", alignItems:{ xs: 'flex-start', sm: 'center' } }}
+      >
+        <Typography
+            variant="h4"
+            component="h1"
+            sx={{ fontWeight: 600, mb: 0.5 }}
+          >
+          Notifications
+        </Typography>
+        {unreadCount > 0 && (
+          <Button variant="outlined" onClick={() => markAllRead.mutate()}>
+            Mark all as read
+          </Button>
+        )}
+      </Stack>
+
+        {isLoading ? (
+        <Box sx={{display:"flex", justifyContent:"center", py:3}}>
+          <CircularProgress />
+        </Box>
+      ) : !notifications ? (
+        <Box sx={{textAlign:"center", py:3}}>
+          <Typography color="text.secondary">
+            Unable to load notifications at this time
+          </Typography>
+        </Box>
+      ) : notifications.length === 0 ? (
+        <Box sx={{textAlign:"center", py:3}}>
+          <Typography color="text.secondary">No notifications yet</Typography>
+        </Box>
+
+      ) : (
+        <Box>
+          {notifications.map((n, idx) => (
+            <Box key={n.id}>
+              <ListItemButton
+                onClick={() => handleClick(n)}
+                sx={{
+                  py: 1.5,
+                  display: "block",
+                  bgcolor: n.isRead ? 'transparent' : 'action.hover',
+                  '&:hover': { bgcolor: 'action.selected' },
+                }}
+              >
+                <Box sx={{display:"flex", justifyContent:"space-between", alignItems:"center", width:"100%"}}>
+                  <Typography variant="body2" sx={{ fontWeight: n.isRead ? 400 : 600 }}>
+                    {n.title}
+                  </Typography>
+                  <Typography variant="caption" color="text.disabled">
+                    {dayjs(n.createdAt).fromNow()}
+                  </Typography>
+                </Box>
+                {n.body && (
+                  <Typography variant="body2" color="text.secondary">
+                    {n.body}
+                  </Typography>
+                )}
+                
+              </ListItemButton>
+              {idx < notifications.length - 1 && <Divider />}
+            </Box>
+          ))}
+          <TablePagination
+            component="div"
+            count={total}
+            page={page}
+            onPageChange={(_, newPage) => setPage(newPage)}
+            rowsPerPage={rowsPerPage}
+            rowsPerPageOptions={[rowsPerPage]}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/src/modules/notifications/Notifications.tsx
+++ b/src/modules/notifications/Notifications.tsx
@@ -23,11 +23,9 @@ export default function Notifications() {
   const [page, setPage] = useState(0);
   const rowsPerPage = 20;
 
-  const { data, isLoading } = useNotifications(page + 1, rowsPerPage);
+  const { data, isLoading, isError } = useNotifications(page + 1, rowsPerPage);
   const markRead = useMarkNotificationRead();
   const markAllRead = useMarkAllNotificationsRead();
-
-  const { isError } = useNotifications(1, 20); 
   const notifications = data?.data ?? [];
   const total = data?.total ?? 0;
   const unreadCount = data?.unreadCount ?? 0;

--- a/src/modules/notifications/hooks.ts
+++ b/src/modules/notifications/hooks.ts
@@ -1,0 +1,55 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import ajax from '../../utils/ajax';
+import { remoteRoutes } from '../../data/constants';
+import type { Notification } from '../../utils/types';
+
+export const notificationKeys = {
+  list: ['notifications', 'list'] as const,
+  unreadCount: ['notifications', 'unread-count'] as const,
+};
+
+export function useNotifications(page = 1, limit = 20) {
+  return useQuery({
+    queryKey: [...notificationKeys.list, page, limit],
+    queryFn: async () => {
+      const r = await ajax.get(remoteRoutes.notificationMessages, {
+        params: { page, limit },
+      });
+      return r.data as { data: Notification[]; total: number; unreadCount: number };
+    },
+  });
+}
+
+export function useUnreadCount() {
+  return useQuery({
+    queryKey: notificationKeys.unreadCount,
+    queryFn: async () => {
+      const r = await ajax.get(`${remoteRoutes.notificationMessages}/unread-count`);
+      return r.data.count as number;
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function useMarkNotificationRead() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) =>
+      ajax.patch(`${remoteRoutes.notificationMessages}/${id}/read`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: notificationKeys.list });
+      qc.invalidateQueries({ queryKey: notificationKeys.unreadCount });
+    },
+  });
+}
+
+export function useMarkAllNotificationsRead() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => ajax.patch(`${remoteRoutes.notificationMessages}/read-all`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: notificationKeys.list });
+      qc.invalidateQueries({ queryKey: notificationKeys.unreadCount });
+    },
+  });
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -77,6 +77,7 @@ export const TYPE_LABELS: Record<TaskType, string> = {
 // utils/types.ts — add near the Task section
 export const NotificationType = {
   TASK_ASSIGNED: 'task_assigned',
+  TASK_REASSIGNED: 'task_reassigned',
   TASK_DUE: 'task_due',
   REPORT_SUBMITTED: 'report_submitted',
   SCHEDULE_CHANGED: 'schedule_changed',

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -74,7 +74,25 @@ export const TYPE_LABELS: Record<TaskType, string> = {
   [TaskType.MATCH]: 'Match',
   [TaskType.FOLLOW_UP]: 'Follow Up',
 };
+// utils/types.ts — add near the Task section
+export const NotificationType = {
+  TASK_ASSIGNED: 'task_assigned',
+  TASK_DUE: 'task_due',
+  REPORT_SUBMITTED: 'report_submitted',
+  SCHEDULE_CHANGED: 'schedule_changed',
+  GENERIC: 'generic',
+} as const;
+export type NotificationType = typeof NotificationType[keyof typeof NotificationType];
 
+export interface Notification {
+  id: number;
+  type: NotificationType;
+  title: string;
+  body: string | null;
+  link: string | null;
+  isRead: boolean;
+  createdAt: string;
+}
 export const NEXT_STATUS_OPTIONS: TaskStatus[] = [
   TaskStatus.IN_PROGRESS,
   TaskStatus.DONE,


### PR DESCRIPTION
# Ticket No
- N/A — internal feature build (in-app notifications)

# Summary of changes
- Added frontend pieces: `NotificationBell` (dropdown preview + unread badge), a dedicated `/notifications` page, `useNotificationSocket` hook, and React Query hooks (`useNotifications`, `useUnreadCount`, `useMarkNotificationRead`, `useMarkAllNotificationsRead`). Socket connection is established once at the layout (`Header`) level via a new `useAuthToken` hook, since the auth token lives in `localStorage`, not redux.

# How should this be tested?
- Create a task and assign it to a user; confirm that user receives a toast + updated bell badge in real time (no refresh needed), and the notification appears in both the bell dropdown and `/notifications` page.
- Reassign an existing task to a different user; confirm the same as above for the new assignee.
- Submit a report tied to a group that has an active leader (directly or via an ancestor group); confirm the leader(s) receive a `REPORT_SUBMITTED` notification.
- Submit a report for a group with no assigned leader anywhere in its ancestor chain; confirm submission still succeeds normally and simply produces no notification (expected — logged as a warning, not an error).
- Click a notification in the bell dropdown or notifications page; confirm it navigates to the linked task/report submission and marks itself read.
- Use "Mark all as read" and confirm the unread badge clears.

# Notes for reviewers

# Out of scope
- Notifications for global (non-group-scoped) report submissions.
- Push notifications outside the app (browser push, email digests beyond the existing weekly summary).
- Notification preferences/settings (mute types, per-user delivery channel choices).
- Retroactive backfill of notifications for tasks/reports created before this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a Notifications page (`/notifications`) and a “Notifications” entry in the main navigation.
  * Introduced a Notification Bell showing an unread badge, with a dropdown preview of recent notifications, “Mark all read”, and per-notification actions.
  * Enabled real-time notification updates to refresh the unread count and show toast alerts.
  * Updated the mobile side menu to use the same Notification Bell for consistent access and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->