### PR TITLE
fix(breadcrumbs): derive active page label from current route

### DIFF
--- a/src/components/layout-v2/NavbarBreadcrumbs.tsx
+++ b/src/components/layout-v2/NavbarBreadcrumbs.tsx
@@ -28,7 +28,7 @@ function pathToRegex(path: string): RegExp {
         : segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
     )
     .join('/');
-  return new RegExp(`^${pattern}$`);
+  return new RegExp(`^${pattern}/?$`); // allow one optional trailing slash
 }
 
 // Turn a constants key like 'financialCategoryRules' into 'Financial Category Rules'
@@ -38,15 +38,30 @@ function humanizeKey(key: string): string {
     .replace(/^./, (c) => c.toUpperCase());
 }
 
-// Built once from localRoutes — most specific (most segments) first, so e.g.
-// '/tasks/mine' is checked before the more generic '/tasks'.
+// Built once from localRoutes
 const routeEntries = Object.entries(localRoutes)
-  .map(([key, path]) => ({ key, path, regex: pathToRegex(path) }))
-  .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
+  .map(([key, path]) => {
+    const segments = path.split('/').filter(Boolean);
+    return {
+      key,
+      path,
+      regex: pathToRegex(path),
+      depth: segments.length,
+      staticSegments: segments.filter((s) => !s.startsWith(':')).length,
+    };
+  })
+  .sort(
+    (a, b) => b.depth - a.depth || b.staticSegments - a.staticSegments,
+  );
+
+function normalizePathname(pathname: string): string {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+}
 
 function getPageLabel(pathname: string): string {
-  if (pathname === '/' || pathname === localRoutes.dashboard) return 'Home';
-  const match = routeEntries.find(({ regex }) => regex.test(pathname));
+  const path = normalizePathname(pathname);
+  if (path === '/' || path === localRoutes.dashboard) return 'Home';
+  const match = routeEntries.find(({ regex }) => regex.test(path));
   return match ? humanizeKey(match.key) : 'Home';
 }
 

--- a/src/components/layout-v2/NavbarBreadcrumbs.tsx
+++ b/src/components/layout-v2/NavbarBreadcrumbs.tsx
@@ -1,7 +1,10 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import Breadcrumbs, { breadcrumbsClasses } from '@mui/material/Breadcrumbs';
 import NavigateNextRoundedIcon from '@mui/icons-material/NavigateNextRounded';
+import { localRoutes } from '../../data/constants';
 
 const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => ({
   margin: theme.spacing(1, 0),
@@ -14,7 +17,43 @@ const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => ({
   },
 }));
 
+// Turn a path like '/admin/financial-management/category-rules' into a regex,
+// treating ':param' segments as wildcards.
+function pathToRegex(path: string): RegExp {
+  const pattern = path
+    .split('/')
+    .map((segment) =>
+      segment.startsWith(':')
+        ? '[^/]+'
+        : segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    )
+    .join('/');
+  return new RegExp(`^${pattern}$`);
+}
+
+// Turn a constants key like 'financialCategoryRules' into 'Financial Category Rules'
+function humanizeKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+// Built once from localRoutes — most specific (most segments) first, so e.g.
+// '/tasks/mine' is checked before the more generic '/tasks'.
+const routeEntries = Object.entries(localRoutes)
+  .map(([key, path]) => ({ key, path, regex: pathToRegex(path) }))
+  .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
+
+function getPageLabel(pathname: string): string {
+  if (pathname === '/' || pathname === localRoutes.dashboard) return 'Home';
+  const match = routeEntries.find(({ regex }) => regex.test(pathname));
+  return match ? humanizeKey(match.key) : 'Home';
+}
+
 export default function NavbarBreadcrumbs() {
+  const { pathname } = useLocation();
+  const currentPage = useMemo(() => getPageLabel(pathname), [pathname]);
+
   return (
     <StyledBreadcrumbs
       aria-label="breadcrumb"
@@ -22,7 +61,7 @@ export default function NavbarBreadcrumbs() {
     >
       <Typography variant="body1">Dashboard</Typography>
       <Typography variant="body1" sx={{ color: 'text.primary', fontWeight: 600 }}>
-        Home
+        {currentPage}
       </Typography>
     </StyledBreadcrumbs>
   );

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -68,7 +68,7 @@ export const localRoutes = {
 
   events: '/events',
   eventsDetails: '/events/:eventId',
-  eventActivities: '/events/:activitiesId',
+  // eventActivities: '/events/:activitiesId',
 
   reports: '/reports',
   reportsDetails: '/reports/:reportId',


### PR DESCRIPTION
# Ticket No
- N/A

# Summary of changes
- Replaced static "Home" label in `NavbarBreadcrumbs` with a dynamic label derived from the current route
- Added `pathToRegex` to match the current pathname against `localRoutes` (including `:param` segments)
- Added `humanizeKey` to auto-generate a readable label from the matched route's constant key (e.g. `financialCategoryRules` → "Financial Category Rules"), so no manual label list needs to be maintained
- Routes are sorted most-specific-first so nested paths (e.g. `/tasks/mine`) resolve before their parent (`/tasks`)
- Root/dashboard route (`/` or `/dashboard`) now explicitly resolves to "Home" instead of "Dashboard", so the breadcrumb reads `Dashboard > Home` on the landing page

# How should this be tested?
- Navigate to each top-level section (Contacts, Reports, Groups, Tasks, Finance, Admin) and confirm the second breadcrumb segment matches the page
- Navigate to a nested/dynamic route (e.g. a contact detail page) and confirm it shows a sensible label, not a raw ID
- Navigate to `/` and `/dashboard` and confirm the breadcrumb reads `Dashboard > Home`

# Notes for reviewers
- Labels are derived automatically from `localRoutes` keys rather than a hardcoded map, so new routes are picked up without further changes to this component

# Out of scope
- Making intermediate breadcrumb segments clickable/linked (currently only a two-level crumb: section root + current page)
- Renaming `localRoutes` keys for nicer auto-generated labels (e.g. `tasksMine` → "My Tasks")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Breadcrumbs now compute the page name from the current URL, instead of always showing “Home.”
  * Dynamic routes are matched and displayed with human-readable labels.
  * The breadcrumb page name mapping was updated to reflect the removed local route entry for event activities (preventing incorrect labeling).


<!-- end of auto-generated comment: release notes by coderabbit.ai -->