### PR TITLE
chore: merge develop into master

### DIFF
--- a/.claude/skills/pr-review-merge/SKILL.md
+++ b/.claude/skills/pr-review-merge/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: pr-review-merge
+description: Review a Project Zoe PR (server or client repo), run all merge-readiness gates, and triage it for human merge - label + route to the Maintainers team (routine) or Senior Engineering team (sensitive paths). Usage - /pr-review-merge <PR number or URL>. This skill never approves or merges; a human maintainer does that in the GitHub UI.
+---
+
+# PR Review & Triage — Project Zoe
+
+You are the second reviewer and the triage step for a multi-tenant church RMS.
+CodeRabbit has already done a mechanical first pass; your job is judgment —
+business logic, domain edge cases, multi-tenant correctness — and routing the
+PR to the right humans. **Merging deploys automatically (develop → staging,
+master → production including `npm run migration:run`). This skill never
+approves or merges anything — the approve + merge is always a human maintainer
+action in the GitHub UI.** Your output determines who reviews, not whether it
+ships.
+
+Routing depends only on what the diff touches — never on who invoked the skill.
+
+## Step 1 — Identify the repo and load its config
+
+Run `git remote get-url origin` in the current directory.
+
+- Contains `project-zoe-server` → use the **Server** config below.
+- Contains `project-zoe-client` → use the **Client** config below.
+- Anything else → stop and tell the user this skill only works inside the
+  project-zoe-server or project-zoe-client repos.
+
+If no PR number/URL was given as an argument, ask which PR to review.
+
+## Step 2 — Gather everything before judging anything
+
+Run all of these (substitute the PR number):
+
+```bash
+gh pr view <N> --json number,title,body,state,isDraft,baseRefName,headRefName,author,additions,deletions,files
+gh pr diff <N>
+gh pr checks <N>
+```
+
+And the review-thread state (the REST API does not expose thread resolution —
+this must be GraphQL). Use the owner/repo from the remote:
+
+```bash
+gh api graphql -f query='query {
+  repository(owner: "kanzucodefoundation", name: "<REPO>") {
+    pullRequest(number: <N>) {
+      reviews(first: 50) { nodes { author { login } state } }
+      reviewThreads(first: 100) {
+        nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } body path } } }
+      }
+    }
+  }
+}'
+```
+
+If the PR is not OPEN, or is a draft, report that and stop.
+
+## Step 3 — Sensitive-path scan (decides routing, checked first)
+
+Check every changed file against the repo's sensitive list, and scan the diff
+for the content triggers. The result decides which of the two triage outcomes
+the PR gets in Step 6 — routine (Maintainers) or sensitive (Senior
+Engineering). Sensitive PRs always get the full adversarial review (Step 5).
+
+**Release PRs (base `master`):** merging to master deploys production and
+auto-runs migrations, but a release PR is not a third tier — it gets whichever
+of the two outcomes its diff earns, same as any other PR. Run the scan over
+the **full cumulative diff** (`gh pr diff`), not per-commit: if the cumulative
+develop→master diff is clean, it routes to Maintainers like any routine PR
+(note in your output that merging it deploys production); if it touches
+anything sensitive, it routes to Senior Engineering.
+
+Release PRs get one gate adjustment in Step 4: CodeRabbit skips reviews on
+base `master` (its check reports "Review skipped" but passes), so gate 1 is
+waived for them; gate 2 still applies to any human threads on the release PR.
+
+### Server (`project-zoe-server`)
+
+- `src/**/*.entity.ts` — any entity file (schema shape)
+- `src/migrations/**` — migrations auto-run against production on deploy
+- `src/data-source.ts`, `src/config.ts` — ORM/connection config
+- Content trigger: any **added** diff line matching `synchronize:\s*true`
+- `src/auth/**` — guards, strategies, JWT helpers
+- `src/middleware/**` — JWT/tenant-header middleware
+- `src/interceptors/tenant-context.interceptor.ts`
+- `src/shared/tenant/**`, `src/shared/repository/**`, `src/shared/interceptors/**`, `src/shared/db.service.ts` — tenant isolation core
+- `src/tenants/**`
+- `src/groups/services/group-permissions.service.ts`, `src/groups/services/group-tree.service.ts` — permission cascade and data-visibility expansion
+- `src/finance/**` — real money
+- `.github/workflows/**` — deploy pipeline with production SSH access
+
+### Client (`project-zoe-client`)
+
+- `src/utils/ajax.ts` — API transport and auth-token handling
+- `src/utils/permissions.ts` — capability checks
+- `src/utils/types.ts` — server response shapes
+- `src/data/constants.ts` — `remoteRoutes` (the API contract) and auth storage keys
+- `src/data/coreSlice.ts`, `src/data/store.ts` — auth/session state
+- `src/App.tsx` — capability-gated routing
+- `src/modules/login/**` — login/password/reset flows
+- `.github/workflows/**` — deploy pipeline
+
+## Step 4 — Merge-readiness gates (all must pass before triage)
+
+Evaluate each and record pass/fail with specifics:
+
+1. **CodeRabbit reviewed.** At least one review by `coderabbitai` exists on the
+   PR (its reviews have state `COMMENTED` — it never approves; that's normal).
+   Waived for release PRs to master (see Step 3). If no review exists —
+   usually the quota ran out — the failure comment must tell the author to
+   trigger one by commenting `@coderabbitai full review` on the PR and re-run
+   this skill once it completes.
+2. **All review threads resolved.** Every `reviewThreads` node has
+   `isResolved: true`. An unresolved thread that is `isOutdated: true` still
+   fails this gate — outdated is not resolved; someone must close the loop.
+   Quote the first comment of each unresolved thread in your output.
+3. **CI green.** From `gh pr checks`: the `test` check must be present and
+   passing, the `CodeRabbit` check must show "Review completed" (or "Review
+   skipped" on release PRs), and every other reported check (e.g.
+   `Analyze`/CodeQL on PRs to master) must pass. No checks pending, no checks
+   failed, `test` not missing.
+4. **Non-trivial description.** The body must contain real content beyond the
+   PR template scaffold. A body that is only unfilled placeholders ("Summary of
+   changes here", "Ticket number here") plus CodeRabbit's auto-generated
+   summary fails. Real content with some leftover placeholders passes — note
+   the leftovers.
+5. **No credential-shaped files.** Fail hard if the diff touches any of:
+   `.env*`, `*.pem`, `*.key`, `id_rsa*`, `*.dump`, `*credentials*`,
+   `*secrets*`, or adds anything that looks like a real secret value in code.
+6. **Lockfile flagged.** If `package-lock.json` changed, this is a **distinct,
+   named item** in your output, always: state whether the lockfile change is
+   explained by a corresponding `package.json` change and roughly what
+   dependencies moved. An unexplained lockfile change (no matching
+   `package.json` edit, or far larger than the stated purpose) fails the gate.
+   An explained one passes but is still reported as its own line item.
+
+## Step 5 — Your own review
+
+**Default: light pass.** Read the full diff and, for any file where the change
+depends on surrounding context (services, business logic, anything stateful),
+read the changed file itself. You are looking for what CodeRabbit misses:
+
+- Does the diff actually do what the description claims — all of it, and
+  nothing undisclosed?
+- Business-logic and domain correctness (group hierarchy, fellowship vs
+  location vs structure semantics, reporting periods, attendance tracks —
+  see the server repo's CLAUDE.md).
+- **Multi-tenant correctness** (server): new queries must be tenant-scoped —
+  `TenantAwareRepository`, or an explicit `tenantId` filter. Any query that
+  could return another tenant's rows is a blocking finding.
+- Client: does the code agree with the server's actual response shapes and
+  `remoteRoutes`?
+
+**Escalate to the full adversarial pass** (persona and output format in
+[critical-code-review.md](critical-code-review.md), use it as-is) when:
+- the PR touches a sensitive path (always adversarial), or
+- the light pass finds anything worth digging into.
+
+## Step 6 — Outcome
+
+All comments are posted with `gh pr comment <N> --body ...`. Write every
+comment as a **teaching artifact for junior engineers**: state plainly what you
+found and why it matters in this codebase — not just pass/fail labels. Always
+include the lockfile line item if applicable, and — explicitly — anything you
+found that CodeRabbit missed ("CodeRabbit did not flag X; it matters
+because Y").
+
+### Any gate failed → comment and stop
+
+Post a comment listing each failed gate with specifics (and your review
+findings so far). Apply no labels and request no reviewers — the author has
+work to do first; re-run the skill afterwards.
+
+### Clean pass, no sensitive path → route to Maintainers
+
+1. Post your review summary as a comment: what you checked, findings, minor
+   non-blocking notes. For release PRs, state that merging deploys production.
+2. `gh pr edit <N> --add-label ready-for-maintainer-review`
+   (create the label first if the repo doesn't have it)
+3. `gh pr edit <N> --add-reviewer kanzucodefoundation/maintainers`
+4. Tell the user the PR is ready for any maintainer to approve and merge in
+   the GitHub UI.
+
+### Clean pass, sensitive path touched → route to Senior Engineering
+
+1. Post the adversarial review as a comment, opening with the routing reason,
+   e.g.: "This touches `src/migrations/…` [schema] — route to the Senior
+   Engineering Team before merging. Migrations auto-run against the production
+   database on deploy, so schema changes always get a senior review." Make
+   clear the PR may well be fine — it just requires senior eyes.
+2. `gh pr edit <N> --add-label needs-senior-review`
+   (create the label first if the repo doesn't have it)
+3. `gh pr edit <N> --add-reviewer kanzucodefoundation/senior-engineering`
+4. Tell the user it's awaiting Senior Engineering review.
+
+If a PR is both sensitive **and** has gate failures, use the gate-failure
+outcome but include the sensitivity finding in the comment so nobody is
+surprised on the re-run.

--- a/.claude/skills/pr-review-merge/SKILL.md
+++ b/.claude/skills/pr-review-merge/SKILL.md
@@ -44,14 +44,26 @@ this must be GraphQL). Use the owner/repo from the remote:
 gh api graphql -f query='query {
   repository(owner: "kanzucodefoundation", name: "<REPO>") {
     pullRequest(number: <N>) {
-      reviews(first: 50) { nodes { author { login } state } }
+      reviews(first: 50) {
+        pageInfo { hasNextPage endCursor }
+        nodes { author { login } state }
+      }
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage endCursor }
         nodes { isResolved isOutdated comments(first: 1) { nodes { author { login } body path } } }
       }
     }
   }
 }'
 ```
+
+If either `pageInfo.hasNextPage` is true, keep fetching with
+`after: "<endCursor>"` until both connections are exhausted. Never judge
+gate 2 on truncated thread data.
+
+The owner is intentionally hardcoded: contributors often work from forks, and
+the PR always lives in the `kanzucodefoundation` upstream — deriving the owner
+from `origin` would break fork clones.
 
 If the PR is not OPEN, or is a draft, report that and stop.
 
@@ -70,9 +82,14 @@ develop→master diff is clean, it routes to Maintainers like any routine PR
 (note in your output that merging it deploys production); if it touches
 anything sensitive, it routes to Senior Engineering.
 
-Release PRs get one gate adjustment in Step 4: CodeRabbit skips reviews on
-base `master` (its check reports "Review skipped" but passes), so gate 1 is
-waived for them; gate 2 still applies to any human threads on the release PR.
+A release PR is specifically head `develop` into base `master`. Only release
+PRs get the gate adjustment in Step 4: CodeRabbit skips auto-review on base
+`master` (its check reports "Review skipped" but passes), so gate 1 is waived
+for them; gate 2 still applies to any human threads on the release PR. A
+master-targeted PR from **any other head branch is not a release PR** — gate 1
+applies in full, and since CodeRabbit doesn't auto-review master-based PRs,
+the author must trigger one with `@coderabbitai full review` before that gate
+can pass.
 
 ### Server (`project-zoe-server`)
 

--- a/.claude/skills/pr-review-merge/SKILL.md
+++ b/.claude/skills/pr-review-merge/SKILL.md
@@ -25,7 +25,12 @@ Run `git remote get-url origin` in the current directory.
 - Anything else → stop and tell the user this skill only works inside the
   project-zoe-server or project-zoe-client repos.
 
-If no PR number/URL was given as an argument, ask which PR to review.
+**Normalize the PR reference to a bare number before using it in any
+command.** If given a URL, it must point at the detected repo under
+`kanzucodefoundation` — extract the number; if it points anywhere else, stop
+and say so. If the argument is neither a number nor such a URL, or no argument
+was given, ask which PR to review. Only the validated number is ever
+substituted into commands.
 
 ## Step 2 — Gather everything before judging anything
 
@@ -38,7 +43,8 @@ gh pr checks <N>
 ```
 
 And the review-thread state (the REST API does not expose thread resolution —
-this must be GraphQL). Use the owner/repo from the remote:
+this must be GraphQL). Substitute `<REPO>` with the repo name from Step 1; the
+owner is always `kanzucodefoundation` (see note below):
 
 ```bash
 gh api graphql -f query='query {
@@ -83,13 +89,13 @@ develop→master diff is clean, it routes to Maintainers like any routine PR
 anything sensitive, it routes to Senior Engineering.
 
 A release PR is specifically head `develop` into base `master`. Only release
-PRs get the gate adjustment in Step 4: CodeRabbit skips auto-review on base
-`master` (its check reports "Review skipped" but passes), so gate 1 is waived
-for them; gate 2 still applies to any human threads on the release PR. A
-master-targeted PR from **any other head branch is not a release PR** — gate 1
-applies in full, and since CodeRabbit doesn't auto-review master-based PRs,
-the author must trigger one with `@coderabbitai full review` before that gate
-can pass.
+PRs get the gate adjustment in Step 4: gate 1 is waived for them, whether or
+not CodeRabbit reviewed the release PR itself (its check may report "Review
+skipped" or post a real review — either way the check passes, and gate 2 still
+applies to any threads on the release PR). A master-targeted PR from **any
+other head branch is not a release PR** — gate 1 applies in full; if CodeRabbit
+hasn't reviewed it, the author must trigger one with `@coderabbitai full
+review` before that gate can pass.
 
 ### Server (`project-zoe-server`)
 

--- a/.claude/skills/pr-review-merge/critical-code-review.md
+++ b/.claude/skills/pr-review-merge/critical-code-review.md
@@ -11,9 +11,11 @@ You are a senior developer with high standards and a low tolerance for incomplet
 2. **Orient to the branch and changes.**
    Run the following in the target directory:
    - `git branch --show-current` — note the branch name and what feature it implies
-   - `git log main...HEAD --oneline` — understand the scope of changes
-   - `git diff main...HEAD --stat` — see which files changed and how much
-   - `git diff main...HEAD` — read the full diff
+   - Resolve the base ref: use one explicitly given by the caller; otherwise
+     `git symbolic-ref refs/remotes/origin/HEAD` (run `git remote set-head origin -a` first if unset)
+   - `git log <base>...HEAD --oneline` — understand the scope of changes
+   - `git diff <base>...HEAD --stat` — see which files changed and how much
+   - `git diff <base>...HEAD` — read the full diff
 
 3. **Read the changed files in full** (not just the diff) for any file where context around the change matters — business logic, models, API endpoints, anything stateful.
 

--- a/.claude/skills/pr-review-merge/critical-code-review.md
+++ b/.claude/skills/pr-review-merge/critical-code-review.md
@@ -1,0 +1,47 @@
+# Critical Code Review
+
+You are a senior developer with high standards and a low tolerance for incomplete thinking. You are reviewing this code not to be encouraging, but to find everything that is wrong with it — design flaws, missing edge cases, error handling gaps, performance problems, security holes, and anything that will cause pain in production.
+
+## Setup
+
+1. **Determine the target.**
+   When invoked from the pr-review-merge skill, the target is the PR diff already gathered — skip to step 3 with that diff.
+   Otherwise: if the user passed a path as an argument (relative or absolute), use it; if not, ask: "Which directory should I review? (relative or absolute path)"
+
+2. **Orient to the branch and changes.**
+   Run the following in the target directory:
+   - `git branch --show-current` — note the branch name and what feature it implies
+   - `git log main...HEAD --oneline` — understand the scope of changes
+   - `git diff main...HEAD --stat` — see which files changed and how much
+   - `git diff main...HEAD` — read the full diff
+
+3. **Read the changed files in full** (not just the diff) for any file where context around the change matters — business logic, models, API endpoints, anything stateful.
+
+## Review Persona
+
+You hate this implementation. Your job is not to validate the author's choices — it is to stress-test them. A finding is worth raising if a reasonable senior developer would push back on it in a real code review.
+
+Challenge:
+
+- **Design decisions** — is this the right approach, or did the author take the easy path? What will this look like in 6 months?
+- **Edge cases** — what inputs, states, or sequences does the code not handle? What happens at the boundaries?
+- **Error handling** — what fails silently? What throws an unhelpful exception? What corrupts state on failure?
+- **Concurrency and race conditions** — if two requests hit this simultaneously, what breaks?
+- **Performance** — what's the query count, memory footprint, or response time under realistic load? What blows up at scale?
+- **Security** — what can a malicious or unexpected input do?
+- **Testability** — is this actually testable, or has the author written something that can only be verified manually?
+- **Assumptions** — what is the code assuming about the caller, the data, or the environment that isn't enforced?
+
+## Output Format
+
+Lead with a one-paragraph verdict: what is the fundamental problem with this implementation (or, if there isn't one, say so plainly).
+
+Then enumerate findings as a numbered list. Each finding must have:
+
+- **What is wrong** — be specific, quote the relevant code or line
+- **Why it matters** — production impact, not abstract principle
+- **What to do instead** — a concrete fix, not "consider improving this"
+
+End with a priority ranking: which three findings would you block the PR on, and why those three.
+
+Do not soften findings. Do not praise what works. If the implementation is genuinely solid, say so in one sentence and move on — but earn that verdict by actually looking for problems first.

--- a/.claude/skills/pr-review-merge/critical-code-review.md
+++ b/.claude/skills/pr-review-merge/critical-code-review.md
@@ -44,6 +44,6 @@ Then enumerate findings as a numbered list. Each finding must have:
 - **Why it matters** — production impact, not abstract principle
 - **What to do instead** — a concrete fix, not "consider improving this"
 
-End with a priority ranking: which three findings would you block the PR on, and why those three.
+End with a priority ranking: up to three findings you would block the PR on, and why. If nothing rises to blocking, say "no blockers" plainly — do not invent findings to fill the ranking.
 
 Do not soften findings. Do not praise what works. If the implementation is genuinely solid, say so in one sentence and move on — but earn that verdict by actually looking for problems first.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,8 +5,10 @@ reviews:
   request_changes_workflow: false
   auto_review:
     enabled: true
-    # develop only: release PRs (develop -> master) contain already-reviewed
-    # commits and are excluded by not listing master here.
+    # CodeRabbit always auto-reviews PRs targeting the default branch (master);
+    # base_branches only ADDS branches — it cannot exclude master. So release
+    # PRs (develop -> master) may get a redundant auto-review; the
+    # pr-review-merge skill does not require it (gate waived for release PRs).
     base_branches:
       - develop
   path_instructions:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,12 +5,10 @@ reviews:
   request_changes_workflow: false
   auto_review:
     enabled: true
+    # develop only: release PRs (develop -> master) contain already-reviewed
+    # commits and are excluded by not listing master here.
     base_branches:
       - develop
-    # Release PRs (develop -> master) contain already-reviewed commits;
-    # skip them to save review quota.
-    ignore_title_keywords:
-      - "merge develop into master"
   path_instructions:
     - path: "src/**/*.{ts,tsx}"
       instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,24 @@
+# CodeRabbit configuration — https://docs.coderabbit.ai/reference/configuration
+# Note: this file overrides any settings made in the CodeRabbit web UI.
+language: en-US
+reviews:
+  request_changes_workflow: false
+  auto_review:
+    enabled: true
+    base_branches:
+      - develop
+    # Release PRs (develop -> master) contain already-reviewed commits;
+    # skip them to save review quota.
+    ignore_title_keywords:
+      - "merge develop into master"
+  path_instructions:
+    - path: "src/**/*.{ts,tsx}"
+      instructions: |
+        API calls go through src/utils/ajax.ts using route constants from
+        src/data/constants.ts (remoteRoutes). Flag hand-rolled fetch/axios calls
+        that bypass ajax.ts, and any change that assumes a server response shape
+        different from the types in src/utils/types.ts.
+    - path: "src/utils/{ajax,permissions}.ts"
+      instructions: |
+        Auth-token handling and capability checks. Scrutinize for token leakage,
+        weakened expiry handling, and capability checks that fail open.

--- a/src/components/layout-v2/NavbarBreadcrumbs.tsx
+++ b/src/components/layout-v2/NavbarBreadcrumbs.tsx
@@ -28,7 +28,7 @@ function pathToRegex(path: string): RegExp {
         : segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
     )
     .join('/');
-  return new RegExp(`^${pattern}$`);
+  return new RegExp(`^${pattern}/?$`); // allow one optional trailing slash
 }
 
 // Turn a constants key like 'financialCategoryRules' into 'Financial Category Rules'
@@ -38,15 +38,30 @@ function humanizeKey(key: string): string {
     .replace(/^./, (c) => c.toUpperCase());
 }
 
-// Built once from localRoutes — most specific (most segments) first, so e.g.
-// '/tasks/mine' is checked before the more generic '/tasks'.
+// Built once from localRoutes
 const routeEntries = Object.entries(localRoutes)
-  .map(([key, path]) => ({ key, path, regex: pathToRegex(path) }))
-  .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
+  .map(([key, path]) => {
+    const segments = path.split('/').filter(Boolean);
+    return {
+      key,
+      path,
+      regex: pathToRegex(path),
+      depth: segments.length,
+      staticSegments: segments.filter((s) => !s.startsWith(':')).length,
+    };
+  })
+  .sort(
+    (a, b) => b.depth - a.depth || b.staticSegments - a.staticSegments,
+  );
+
+function normalizePathname(pathname: string): string {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+}
 
 function getPageLabel(pathname: string): string {
-  if (pathname === '/' || pathname === localRoutes.dashboard) return 'Home';
-  const match = routeEntries.find(({ regex }) => regex.test(pathname));
+  const path = normalizePathname(pathname);
+  if (path === '/' || path === localRoutes.dashboard) return 'Home';
+  const match = routeEntries.find(({ regex }) => regex.test(path));
   return match ? humanizeKey(match.key) : 'Home';
 }
 

--- a/src/components/layout-v2/NavbarBreadcrumbs.tsx
+++ b/src/components/layout-v2/NavbarBreadcrumbs.tsx
@@ -1,7 +1,10 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { styled } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import Breadcrumbs, { breadcrumbsClasses } from '@mui/material/Breadcrumbs';
 import NavigateNextRoundedIcon from '@mui/icons-material/NavigateNextRounded';
+import { localRoutes } from '../../data/constants';
 
 const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => ({
   margin: theme.spacing(1, 0),
@@ -14,7 +17,43 @@ const StyledBreadcrumbs = styled(Breadcrumbs)(({ theme }) => ({
   },
 }));
 
+// Turn a path like '/admin/financial-management/category-rules' into a regex,
+// treating ':param' segments as wildcards.
+function pathToRegex(path: string): RegExp {
+  const pattern = path
+    .split('/')
+    .map((segment) =>
+      segment.startsWith(':')
+        ? '[^/]+'
+        : segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+    )
+    .join('/');
+  return new RegExp(`^${pattern}$`);
+}
+
+// Turn a constants key like 'financialCategoryRules' into 'Financial Category Rules'
+function humanizeKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
+// Built once from localRoutes — most specific (most segments) first, so e.g.
+// '/tasks/mine' is checked before the more generic '/tasks'.
+const routeEntries = Object.entries(localRoutes)
+  .map(([key, path]) => ({ key, path, regex: pathToRegex(path) }))
+  .sort((a, b) => b.path.split('/').length - a.path.split('/').length);
+
+function getPageLabel(pathname: string): string {
+  if (pathname === '/' || pathname === localRoutes.dashboard) return 'Home';
+  const match = routeEntries.find(({ regex }) => regex.test(pathname));
+  return match ? humanizeKey(match.key) : 'Home';
+}
+
 export default function NavbarBreadcrumbs() {
+  const { pathname } = useLocation();
+  const currentPage = useMemo(() => getPageLabel(pathname), [pathname]);
+
   return (
     <StyledBreadcrumbs
       aria-label="breadcrumb"
@@ -22,7 +61,7 @@ export default function NavbarBreadcrumbs() {
     >
       <Typography variant="body1">Dashboard</Typography>
       <Typography variant="body1" sx={{ color: 'text.primary', fontWeight: 600 }}>
-        Home
+        {currentPage}
       </Typography>
     </StyledBreadcrumbs>
   );

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -68,7 +68,7 @@ export const localRoutes = {
 
   events: '/events',
   eventsDetails: '/events/:eventId',
-  eventActivities: '/events/:activitiesId',
+  // eventActivities: '/events/:activitiesId',
 
   reports: '/reports',
   reportsDetails: '/reports/:reportId',

--- a/src/modules/admin/reports/ReportConfiguration.tsx
+++ b/src/modules/admin/reports/ReportConfiguration.tsx
@@ -274,7 +274,8 @@ const ReportConfiguration = () => {
                   color: isInactive ? 'text.secondary' : 'text.primary',
                 },
               }}
-            >              <TableCell sx={{ fontWeight: 'bold' }}>Name</TableCell>
+            >              
+            <TableCell sx={{ fontWeight: 'bold' }}>Name</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>Category</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>Frequency</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>View Type</TableCell>

--- a/src/modules/admin/reports/ReportConfiguration.tsx
+++ b/src/modules/admin/reports/ReportConfiguration.tsx
@@ -263,14 +263,18 @@ const ReportConfiguration = () => {
       <TableContainer
         component={Paper}
         variant="outlined"
-        sx={{
-          backgroundColor: isInactive ? 'grey.50' : '#fff',
-        }}
+        sx={{backgroundColor: isInactive ? 'action.hover' : 'background.paper' }}
       >
         <Table size="small">
           <TableHead>
-            <TableRow sx={{ backgroundColor: isInactive ? 'grey.100' : 'grey.50' }}>
-              <TableCell sx={{ fontWeight: 'bold' }}>Name</TableCell>
+            <TableRow
+              sx={{
+                backgroundColor: isInactive ? 'action.selected' : 'action.hover',
+                '& .MuiTableCell-root': {
+                  color: isInactive ? 'text.secondary' : 'text.primary',
+                },
+              }}
+            >              <TableCell sx={{ fontWeight: 'bold' }}>Name</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>Category</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>Frequency</TableCell>
               <TableCell sx={{ fontWeight: 'bold' }}>View Type</TableCell>
@@ -382,7 +386,7 @@ const ReportConfiguration = () => {
               cursor: 'pointer',
               py: 1,
               px: 2,
-              backgroundColor: 'grey.100',
+              backgroundColor: 'action.selected',
               borderRadius: 1,
               mb: showInactive ? 2 : 0,
             }}

--- a/src/modules/attendance/history/AttendanceHistory.tsx
+++ b/src/modules/attendance/history/AttendanceHistory.tsx
@@ -285,7 +285,7 @@ export default function AttendanceHistory() {
         </Box>
 
         {/* Filters */}
-        <Stack direction="row" flexWrap="wrap" display="flex" alignItems="center" gap={2}>
+        <Stack direction="row" sx={{flexWrap:"wrap", display:"flex", alignItems:"center", gap:"1rem"}}>
           <Autocomplete
             options={locations}
             getOptionLabel={(o) => o.name}
@@ -340,7 +340,7 @@ export default function AttendanceHistory() {
             <Typography variant="h6" color="text.secondary">
               No services found
             </Typography>
-            <Typography variant="body2" color="text.disabled" sx={{ mt: 0.5 }} textAlign="center">
+            <Typography variant="body2" color="text.disabled" sx={{ mt: 0.5, textAlign:"center" }} >
               {filterLocationId || filterSchedule
                 ? 'Try clearing the filters.'
                 : 'Check-in data will appear here after services run.'}

--- a/src/modules/attendance/history/AttendanceHistory.tsx
+++ b/src/modules/attendance/history/AttendanceHistory.tsx
@@ -285,7 +285,7 @@ export default function AttendanceHistory() {
         </Box>
 
         {/* Filters */}
-        <Stack direction="row" spacing={2} flexWrap="wrap">
+        <Stack direction="row" flexWrap="wrap" display="flex" alignItems="center" gap={2}>
           <Autocomplete
             options={locations}
             getOptionLabel={(o) => o.name}
@@ -340,7 +340,7 @@ export default function AttendanceHistory() {
             <Typography variant="h6" color="text.secondary">
               No services found
             </Typography>
-            <Typography variant="body2" color="text.disabled" sx={{ mt: 0.5 }}>
+            <Typography variant="body2" color="text.disabled" sx={{ mt: 0.5 }} textAlign="center">
               {filterLocationId || filterSchedule
                 ? 'Try clearing the filters.'
                 : 'Check-in data will appear here after services run.'}

--- a/src/modules/attendance/schedules/ScheduleFormDialog.tsx
+++ b/src/modules/attendance/schedules/ScheduleFormDialog.tsx
@@ -150,7 +150,8 @@ export default function ScheduleFormDialog({ open, onClose, editing }: Props) {
     onSuccess: () => {
       toast.success(editing ? 'Schedule updated.' : 'Schedule created.');
       queryClient.invalidateQueries({ queryKey: ['schedules'] });
-      handleClose();
+      onClose();
+      formik.resetForm({ values: defaultValues });
     },
     onError: (error: any) => {
       const message =

--- a/src/modules/attendance/schedules/ServiceSchedules.tsx
+++ b/src/modules/attendance/schedules/ServiceSchedules.tsx
@@ -122,7 +122,7 @@ export default function ServiceSchedules() {
         ) : null}
 
         {/* Filters */}
-        <Stack direction="row" flexWrap="wrap" display="flex" alignItems="center" gap={2}>
+        <Stack direction="row" sx={{flexWrap:"wrap", display:"flex", alignItems:"center", gap:"1rem"}}>
           <Autocomplete
             options={locations}
             getOptionLabel={(o) => o.name}
@@ -172,7 +172,7 @@ export default function ServiceSchedules() {
             <Typography variant="h6" color="text.secondary">
               No schedules found
             </Typography>
-            <Typography variant="body2" color="text.disabled" textAlign="center">
+            <Typography variant="body2" color="text.disabled" sx={{textAlign:"center" }}>
               {filterLocationId || filterType !== 'all'
                 ? 'Try clearing the filters.'
                 : 'Create your first service schedule to get started.'}

--- a/src/modules/attendance/schedules/ServiceSchedules.tsx
+++ b/src/modules/attendance/schedules/ServiceSchedules.tsx
@@ -122,7 +122,7 @@ export default function ServiceSchedules() {
         ) : null}
 
         {/* Filters */}
-        <Stack direction="row" spacing={2} flexWrap="wrap">
+        <Stack direction="row" flexWrap="wrap" display="flex" alignItems="center" gap={2}>
           <Autocomplete
             options={locations}
             getOptionLabel={(o) => o.name}
@@ -172,7 +172,7 @@ export default function ServiceSchedules() {
             <Typography variant="h6" color="text.secondary">
               No schedules found
             </Typography>
-            <Typography variant="body2" color="text.disabled">
+            <Typography variant="body2" color="text.disabled" textAlign="center">
               {filterLocationId || filterType !== 'all'
                 ? 'Try clearing the filters.'
                 : 'Create your first service schedule to get started.'}

--- a/src/modules/contacts/Contacts.tsx
+++ b/src/modules/contacts/Contacts.tsx
@@ -361,7 +361,7 @@ const Contacts = () => {
                           component="a"
                           href={`tel:${contact.phone}`}
                           onClick={(e) => e.stopPropagation()}
-                          sx={{ color: 'primary.main', textDecoration: 'none' }}
+                          sx={{ color: 'text.secondary', textDecoration: 'none' }}
                         >
                           {contact.phone}
                         </Typography>
@@ -372,7 +372,7 @@ const Contacts = () => {
                           component="a"
                           href={`mailto:${contact.email}`}
                           onClick={(e) => e.stopPropagation()}
-                          sx={{ color: 'primary.main', textDecoration: 'none' }}
+                          sx={{ color: 'text.secondary', textDecoration: 'none'}}
                         >
                           {contact.email}
                         </Typography>

--- a/src/modules/contacts/Contacts.tsx
+++ b/src/modules/contacts/Contacts.tsx
@@ -26,6 +26,7 @@ import {
   Stack,
   Chip,
   Divider,
+  Alert,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
@@ -85,6 +86,8 @@ const Contacts = () => {
 
   const [createDialog, setCreateDialog] = useState(false);
   const [uploadDialog, setUploadDialog] = useState(false);
+  const [editDialog, setEditDialog] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
   const [filter, setFilter] = useState<ContactFilter>({
     limit: CONTACT_FETCH_LIMIT,
     skip: 0,
@@ -204,6 +207,20 @@ const Contacts = () => {
       navigate(`${localRoutes.contacts}/${selectedContact.id}`);
     }
     handleMenuClose();
+  };
+
+  const handleEdit = () => {
+    setEditError(null);
+    setEditDialog(true);
+    setAnchorEl(null);
+  };
+
+  const handleEditSave = () => {
+    setEditError(null);
+    setEditDialog(false);
+    setSelectedContact(null);
+    // Refresh contacts list; keep same pagination
+    setFilter((prev) => ({ ...prev }));
   };
 
   const getInitials = (name: string) => {
@@ -569,7 +586,7 @@ const Contacts = () => {
         onClose={handleMenuClose}
       >
         <MenuItem onClick={handleViewDetails}>View Details</MenuItem>
-        <MenuItem onClick={handleViewDetails}>Edit</MenuItem>
+        <MenuItem onClick={handleEdit}>Edit</MenuItem>
       </Menu>
 
       {/* New Contact Dialog */}
@@ -590,6 +607,39 @@ const Contacts = () => {
               setFilter((prev) => ({ ...prev }));
             }}
             onCancel={() => setCreateDialog(false)}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Contact Dialog */}
+      <Dialog
+        open={editDialog}
+        onClose={() => {
+          setEditError(null);
+          setEditDialog(false);
+          setSelectedContact(null);
+        }}
+        maxWidth="md"
+        fullWidth
+        fullScreen={isMobile}
+        scroll="paper"
+      >
+        <DialogTitle>Edit Contact</DialogTitle>
+        <DialogContent dividers={isMobile}>
+          {editError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {editError}
+            </Alert>
+          )}
+          <ContactForm
+            contactId={selectedContact?.id}
+            onSave={handleEditSave}
+            onCancel={() => {
+              setEditError(null);
+              setEditDialog(false);
+              setSelectedContact(null);
+            }}
+            onError={(message) => setEditError(message || null)}
           />
         </DialogContent>
       </Dialog>

--- a/src/modules/contacts/Contacts.tsx
+++ b/src/modules/contacts/Contacts.tsx
@@ -208,7 +208,11 @@ const Contacts = () => {
     }
     handleMenuClose();
   };
-
+  const handleEditClose = () => {
+    setEditError(null);
+    setEditDialog(false);
+    setSelectedContact(null);
+  }
   const handleEdit = () => {
     setEditError(null);
     setEditDialog(true);
@@ -216,9 +220,7 @@ const Contacts = () => {
   };
 
   const handleEditSave = () => {
-    setEditError(null);
-    setEditDialog(false);
-    setSelectedContact(null);
+    handleEditClose()
     // Refresh contacts list; keep same pagination
     setFilter((prev) => ({ ...prev }));
   };
@@ -614,11 +616,7 @@ const Contacts = () => {
       {/* Edit Contact Dialog */}
       <Dialog
         open={editDialog}
-        onClose={() => {
-          setEditError(null);
-          setEditDialog(false);
-          setSelectedContact(null);
-        }}
+        onClose={handleEditClose}
         maxWidth="md"
         fullWidth
         fullScreen={isMobile}
@@ -634,11 +632,7 @@ const Contacts = () => {
           <ContactForm
             contactId={selectedContact?.id}
             onSave={handleEditSave}
-            onCancel={() => {
-              setEditError(null);
-              setEditDialog(false);
-              setSelectedContact(null);
-            }}
+            onCancel={handleEditClose}
             onError={(message) => setEditError(message || null)}
           />
         </DialogContent>

--- a/src/modules/groups/AddGroupDialog.tsx
+++ b/src/modules/groups/AddGroupDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -36,8 +36,18 @@ interface ComboOption {
   name: string;
 }
 
-const toComboOptions = (data: ComboOption[] | IGroupCategory[]) =>
-  (Array.isArray(data) ? data : []).map(({ id, name }) => ({ id, name }));
+// Same shape as ContactForm's group option: carries the parent's name for display.
+interface GroupOption extends ComboOption {
+  parentName?: string;
+}
+
+// Hierarchical shape returned by remoteRoutes.groups (local to this component,
+// mirrors ContactForm's local GroupNode used purely for flattening).
+type GroupTreeNode = {
+  id: number;
+  name: string;
+  children?: GroupTreeNode[];
+};
 
 const toComboOption = (
   value?: Pick<GroupNode, 'id' | 'name'> | GroupNode['parent'] | null,
@@ -51,6 +61,25 @@ const toComboOption = (
     name: value.name,
   };
 };
+
+// Flatten hierarchical groups, preserving parent name for display (same as ContactForm).
+const flattenGroups = (
+  nodes: GroupTreeNode[] | undefined,
+  parentName?: string,
+): GroupOption[] => {
+  const out: GroupOption[] = [];
+  for (const n of nodes || []) {
+    out.push({ id: n.id, name: n.name, parentName });
+    if (n.children?.length) {
+      out.push(...flattenGroups(n.children, n.name));
+    }
+  }
+  out.sort((a, b) => a.name.localeCompare(b.name));
+  return out;
+};
+
+const getGroupLabel = (option: GroupOption) =>
+  option.parentName ? `${option.name} - ${option.parentName}` : option.name;
 
 const AddGroupDialog = ({
   open,
@@ -68,55 +97,11 @@ const AddGroupDialog = ({
   const [parent, setParent] = useState<ComboOption | null>(null);
   const [address, setAddress] = useState<IAddress | null>(null);
   const [categories, setCategories] = useState<IGroupCategory[]>([]);
-  const [groups, setGroups] = useState<ComboOption[]>([]);
+  const [groups, setGroups] = useState<GroupOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingData, setLoadingData] = useState(true);
 
   const isEditing = !!editGroup;
-
-  const getParentCategory = useCallback(
-    (categoryId: number | undefined | null) => {
-      if (!categoryId) {
-        return null;
-      }
-
-      const orderedCategories = [...categories].sort(
-        (left, right) => left.id - right.id,
-      );
-      const currentIndex = orderedCategories.findIndex(
-        (item) => item.id === categoryId,
-      );
-      if (
-        currentIndex === -1 ||
-        currentIndex === orderedCategories.length - 1
-      ) {
-        return null;
-      }
-
-      return orderedCategories[currentIndex + 1];
-    },
-    [categories],
-  );
-
-  const getParentDropdownCategories = useCallback(
-    (categoryId: number) => {
-      // const currentCategory = categories.find((item) => item.id === categoryId);
-      const higherCategory = getParentCategory(categoryId);
-      const scopedCategories = [higherCategory].filter(
-        (item): item is IGroupCategory => Boolean(item),
-      );
-
-      const uniqueById = new Map<number, IGroupCategory>();
-      scopedCategories.forEach((item) => {
-        if (!uniqueById.has(item.id)) {
-          uniqueById.set(item.id, item);
-        }
-      });
-
-      return Array.from(uniqueById.values());
-    },
-    [categories, getParentCategory],
-  );
 
   useEffect(() => {
     if (open) {
@@ -165,77 +150,39 @@ const AddGroupDialog = ({
     }
   }, [loadingData, open, editGroup, categories]);
 
+  // Fetch the full group hierarchy and flatten it, like ContactForm's Groups field.
+  // Excludes the group currently being edited so it can't be its own parent.
   useEffect(() => {
-    if (!open || !category) {
+    if (!open) {
       setGroups([]);
-      setParent(null);
-      return;
-    }
-
-    const parentCategories = getParentDropdownCategories(category.id);
-    if (!parentCategories.length) {
-      setGroups([]);
-      setParent(null);
       return;
     }
 
     let mounted = true;
 
-    const fetchCategoryGroups = (categoryName: string) =>
-      new Promise<ComboOption[]>((resolve) => {
-        get(
-          `${remoteRoutes.groupsCategories}/${encodeURIComponent(
-            categoryName,
-          )}`,
-          (data: ComboOption[]) => resolve(toComboOptions(data)),
-          () => resolve([]),
-        );
-      });
-
-    Promise.all(parentCategories.map((item) => fetchCategoryGroups(item.name)))
-      .then((allGroups) => {
+    get(
+      remoteRoutes.groups,
+      (data: any) => {
         if (!mounted) {
           return;
         }
-
-        const uniqueGroups = new Map<number, ComboOption>();
-        allGroups.flat().forEach((item) => {
-          if (item.id === editGroup?.id) {
-            return;
-          }
-          if (!uniqueGroups.has(item.id)) {
-            uniqueGroups.set(item.id, item);
-          }
-        });
-
-        const existingParent = toComboOption(editGroup?.parent);
-        const nextGroups = Array.from(uniqueGroups.values());
-        const hasExistingParent = existingParent
-          ? nextGroups.some((item) => `${item.id}` === `${existingParent.id}`)
-          : false;
-
-        if (existingParent && !hasExistingParent) {
-          nextGroups.unshift(existingParent);
-        }
-
-        setGroups(nextGroups);
-      })
-      .catch(() => {
+        const roots: GroupTreeNode[] = Array.isArray(data) ? data : [data];
+        const flat = flattenGroups(roots).filter(
+          (item) => item.id !== editGroup?.id,
+        );
+        setGroups(flat);
+      },
+      () => {
         if (mounted) {
           setGroups([]);
         }
-      });
+      },
+    );
 
     return () => {
       mounted = false;
     };
-  }, [
-    open,
-    category,
-    editGroup?.id,
-    editGroup?.parent,
-    getParentDropdownCategories,
-  ]);
+  }, [open, editGroup?.id]);
 
   useEffect(() => {
     if (!open) {
@@ -379,11 +326,16 @@ const AddGroupDialog = ({
 
             <Autocomplete
               options={groups}
-              getOptionLabel={(option) => option.name}
+              getOptionLabel={getGroupLabel}
               value={parent}
               onChange={(_, newValue) => setParent(newValue)}
               renderInput={(params) => (
                 <TextField {...params} label="Parent Group" />
+              )}
+              renderOption={(props, option) => (
+                <li {...props} key={option.id}>
+                  {getGroupLabel(option)}
+                </li>
               )}
               isOptionEqualToValue={(option, value) => option.id === value.id}
             />

--- a/src/modules/groups/AddGroupDialog.tsx
+++ b/src/modules/groups/AddGroupDialog.tsx
@@ -66,15 +66,17 @@ const toComboOption = (
 const flattenGroups = (
   nodes: GroupTreeNode[] | undefined,
   parentName?: string,
+  excludeId?: number,
 ): GroupOption[] => {
   const out: GroupOption[] = [];
   for (const n of nodes || []) {
-    out.push({ id: n.id, name: n.name, parentName });
+    if (n.id !== excludeId) {
+      out.push({ id: n.id, name: n.name, parentName });
+    }
     if (n.children?.length) {
-      out.push(...flattenGroups(n.children, n.name));
+      out.push(...flattenGroups(n.children, n.name, excludeId));
     }
   }
-  out.sort((a, b) => a.name.localeCompare(b.name));
   return out;
 };
 
@@ -166,10 +168,13 @@ const AddGroupDialog = ({
         if (!mounted) {
           return;
         }
-        const roots: GroupTreeNode[] = Array.isArray(data) ? data : [data];
-        const flat = flattenGroups(roots).filter(
-          (item) => item.id !== editGroup?.id,
-        );
+        const roots: GroupTreeNode[] = Array.isArray(data)
+          ? data
+          : data
+          ? [data]
+          : [];
+        const flat = flattenGroups(roots, undefined, editGroup?.id);
+        flat.sort((a, b) => a.name.localeCompare(b.name));
         setGroups(flat);
       },
       () => {
@@ -332,11 +337,14 @@ const AddGroupDialog = ({
               renderInput={(params) => (
                 <TextField {...params} label="Parent Group" />
               )}
-              renderOption={(props, option) => (
-                <li {...props} key={option.id}>
-                  {getGroupLabel(option)}
-                </li>
-              )}
+              renderOption={(props, option) => {
+                const { key, ...restProps } = props;
+                return (
+                  <li key={option.id} {...restProps}>
+                    {getGroupLabel(option)}
+                  </li>
+                );
+              }}
               isOptionEqualToValue={(option, value) => option.id === value.id}
             />
 

--- a/src/modules/groups/GroupDetails.tsx
+++ b/src/modules/groups/GroupDetails.tsx
@@ -240,7 +240,7 @@ const GroupDetails = () => {
     const fetchAllContacts = async () => {
       setContactsLoading(true);
       try {
-        const data = await getJson<ContactRef[]>(remoteRoutes.contactsPeopleCombo);
+        const data = await getJson<ContactRef[]>(remoteRoutes.contacts);
         if (!ignore) setAllContacts(Array.isArray(data) ? data : []);
       } catch{
         if (!ignore) toast.error('Failed to load people for selection.');

--- a/src/modules/groups/GroupDetails.tsx
+++ b/src/modules/groups/GroupDetails.tsx
@@ -503,7 +503,7 @@ const GroupDetails = () => {
             )}
           </Box>
         </Box>
-        <Box display="flex" gap={1}>
+        <Box sx={{display:"flex", gap:"1rem", flexWrap:"wrap"}} >
           <Button
             variant="contained"
             startIcon={<SmsIcon />}

--- a/src/modules/groups/GroupDetails.tsx
+++ b/src/modules/groups/GroupDetails.tsx
@@ -482,7 +482,7 @@ const GroupDetails = () => {
   return (
     <Container maxWidth="lg">
       {/* Header */}
-      <Box display="flex" alignItems="center" gap={2} mb={3}>
+      <Box display="flex" alignItems="center" gap={2} mb={3} flexWrap="wrap">
         <IconButton onClick={() => navigate(localRoutes.groups)}>
           <ArrowBackIcon />
         </IconButton>
@@ -648,30 +648,31 @@ const GroupDetails = () => {
             alignItems="center"
             gap={2}
             flexWrap="wrap"
-            padding={2}
+            paddingBottom={2}
           >
-              {!membershipsLoading && memberships.length > 0 ? (
-                <Chip
-                  label={`${memberships.length} ${
-                    memberships.length === 1 ? 'person' : 'people'
-                  }`}
-                  size="small"
-                  variant="outlined"
-                />
-              ) : null}
-              {canManageCurrentGroup && (
-                <Button
-                  startIcon={<PersonAddIcon />}
-                  variant="outlined"
-                  size="small"
-                  onClick={() => {
-                    setShowAddMemberForm(!showAddMemberForm);
-                    setSelectedContacts([]);
-                  }}
-                >
-                  {showAddMemberForm ? 'Close' : 'Add Member'}
-                </Button>
-              )}               </Box> 
+            {!membershipsLoading && memberships.length > 0 ? (
+              <Chip
+                label={`${memberships.length} ${
+                  memberships.length === 1 ? 'person' : 'people'
+                }`}
+                size="small"
+                variant="outlined"
+              />
+            ) : null}
+            {canManageCurrentGroup && (
+              <Button
+                startIcon={<PersonAddIcon />}
+                variant="outlined"
+                size="small"
+                onClick={() => {
+                  setShowAddMemberForm(!showAddMemberForm);
+                  setSelectedContacts([]);
+                }}
+              >
+                {showAddMemberForm ? 'Close' : 'Add Member'}
+              </Button>
+            )}               
+          </Box> 
           
         </Box>        
         <Divider sx={{ mb: 2 }} />

--- a/src/modules/login/Login.tsx
+++ b/src/modules/login/Login.tsx
@@ -237,8 +237,6 @@ const Login = () => {
               disabled={loading}
               sx={{
                 py: 1.5,
-                backgroundColor: '#1a2332',
-                '&:hover': { backgroundColor: '#2d4059' },
                 textTransform: 'none',
                 fontSize: '1rem',
                 mb: 2,

--- a/src/modules/login/SignUp.tsx
+++ b/src/modules/login/SignUp.tsx
@@ -587,8 +587,6 @@ const SignUp = () => {
               disabled={isSubmitting}
               sx={{
                 py: 1.5,
-                backgroundColor: '#1a2332',
-                '&:hover': { backgroundColor: '#2d4059' },
                 textTransform: 'none',
                 fontSize: '1rem',
                 mb: 2,

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -568,8 +568,17 @@ const ReportSubmissionForm = () => {
     reportFields.forEach((field) => {
       if (!field.required) return;
       const value = formData[field.name];
-      const isEmpty =
-        field.type === 'checkbox' ||
+      const hasValue = value !== undefined && value !== null && value !== '';
+      if (
+        field.type === 'number' &&
+        hasValue &&
+        (!Number.isFinite(Number(value)) || Number(value) < 0)
+      ) {
+        errors[field.name] = `${field.label || field.name} must be 0 or greater`;
+        return;
+      }
+      if (!field.required) return;
+      const isEmpty =        field.type === 'checkbox' ||
         (field.type === 'select' && isDynamicMemberField(field))
           ? !Array.isArray(value) || value.length === 0
           : value === undefined || value === null || value === '';
@@ -920,6 +929,13 @@ const ReportSubmissionForm = () => {
             required={field.required}
             value={value}
             onChange={(e) => handleChange(field.name, e.target.value)}
+            // Blocks the minus key from being pressed
+            onKeyDown={(e) => {
+              if (e.key === '-' || e.code === 'Minus') {
+                e.preventDefault();
+              }
+            }}
+            inputProps={{ min: 0}}
             error={hasError}
             helperText={validationErrors[field.name]}
           />

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -566,7 +566,6 @@ const ReportSubmissionForm = () => {
     const errors: Record<string, string> = {};
     let hiddenFieldMissing = false;
     reportFields.forEach((field) => {
-      if (!field.required) return;
       const value = formData[field.name];
       const hasValue = value !== undefined && value !== null && value !== '';
       if (

--- a/src/modules/tasks/TaskCard.tsx
+++ b/src/modules/tasks/TaskCard.tsx
@@ -112,7 +112,7 @@ export default function TaskCard({ task, onOpen, showContact = false }: Props) {
             to={`${localRoutes.contacts}/${task.contact.id}`}
             onClick={(e) => e.stopPropagation()}
             sx={{
-              color: 'primary.main',
+              color: 'text.primary',
               textDecoration: 'none',
               display: 'block',
               mb: 0.5,

--- a/src/theme-wh/customizations/feedback.tsx
+++ b/src/theme-wh/customizations/feedback.tsx
@@ -78,9 +78,9 @@ export const feedbackCustomizations: Components<Theme> = {
           color: gray[100],
         }),
       }),
-      circle: () => ({
+      circle:{
         strokeLinecap: 'round',
-      }),
+      },
     },
   },
 };

--- a/src/theme-wh/customizations/feedback.tsx
+++ b/src/theme-wh/customizations/feedback.tsx
@@ -70,4 +70,17 @@ export const feedbackCustomizations: Components<Theme> = {
       }),
     },
   },
+  MuiCircularProgress: {
+    styleOverrides: {
+      root: ({ theme }) => ({
+        color: gray[700],
+        ...theme.applyStyles('dark', {
+          color: gray[100],
+        }),
+      }),
+      circle: () => ({
+        strokeLinecap: 'round',
+      }),
+    },
+  },
 };


### PR DESCRIPTION
# Summary of changes
Release of everything on `develop` (29 commits ahead, 0 behind after back-merge #235):
- UI/UX fixes: schedule dialog auto-close, reports config dark mode, dark-mode visibility, negative numeric input restriction, responsive tweaks, task card name display, breadcrumbs derived from current route.
- Contacts: edit form opens in a modal from the row menu; members dropdown shows all members.
- Groups: parent-group select aligned with ContactForm's groups field; AddGroupDialog/GroupDetails cleanup.
- Login/SignUp: hardcoded button colors removed (theme-driven now) — styling only, no auth logic.
- Tooling: pr-review-merge skill committed to `.claude/skills/`, `.coderabbit.yaml` added.

# How should this be tested?
- Staging runs all of this already. After merge, spot-check login page styling, contacts row-menu edit, group creation, and a report submission.

# Notes for reviewers
- **Merging this deploys the production client.**
- Touches `src/modules/login/**` and `src/data/constants.ts` (sensitive list) → routed to Senior Engineering per policy; see triage comment for why the findings are trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)