### PR TITLE
fix(frontend): defer notification socket connect to avoid StrictMode …

### DIFF
--- a/src/data/useNotificationSocket.ts
+++ b/src/data/useNotificationSocket.ts
@@ -18,7 +18,8 @@ export function useNotificationSocket(token: string | null) {
     const socket = io(NOTIFICATIONS_SOCKET_URL, {
       auth: { token },
       transports: ['websocket'],
-    });    
+      autoConnect: false,
+    });
     socketRef.current = socket;
 
     socket.on('notification:new', (notification) => {
@@ -32,8 +33,10 @@ export function useNotificationSocket(token: string | null) {
     socket.on('connect_error', (err) => {
       console.error('Notification socket connection error:', err.message);
     });
+    const connectTimer = setTimeout(() => socket.connect(), 0);
 
     return () => {
+      clearTimeout(connectTimer);
       socket.disconnect();
       if (socketRef.current === socket) {
         socketRef.current = null;


### PR DESCRIPTION
# Fix: console error on notification socket connect (dev only)

## Summary of Changes

`useNotificationSocket` now uses `autoConnect: false` on the Socket.IO client and defers the actual `connect()` call by one tick via `setTimeout`, clearing that timer in the effect's cleanup. This is a two-line change, no other logic touched.

## How Should This Be Tested

1. Run the app
2. Open the browser console.
3. Confirm the `WebSocket connection to '...' failed: WebSocket is    closed before the connection is established` error no longer appears    on page load.
4. Confirm notifications still arrive live (trigger a task assignment or report submission and confirm the toast/badge update fires as before).
5. Confirm the socket still reconnects correctly on token change (e.g. log out and log back in as a different user).

## Note for Reviewers

- This only affects **development** behavior — React StrictMode's   double-invoke of effects doesn't happen in production builds, so this   warning was never user-facing in production; it was purely console   noise for developers.
- The one-tick delay (`setTimeout(..., 0)`) is imperceptible to actual   connection time in both dev and prod.

## Out of Scope

- Any backend/notifications-service changes.
- Investigating whether the app should fall back to WebSocket-upgrade   failures more gracefully in restrictive network environments (unrelated to this specific warning). 
- Removing React StrictMode (not desired — it's still useful for  catching other effect-cleanup bugs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification connection handling to prevent delayed connections after leaving or switching screens.
  * Ensured pending connection attempts are properly canceled during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->