### PR TITLE
docs: document the PR review & merge workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,25 @@ feature branch → develop (staging) → master (production)
 
 6. Once the change is verified on staging, it is promoted to `master` via a separate PR, which triggers the production deploy.
 
+## PR review & merge
+
+Every PR passes through three layers before it can merge. `develop` and `master` are protected: direct pushes are blocked, one approving review is required (pushing new commits dismisses earlier approvals), the `test` and `CodeRabbit` checks must pass, and only the Maintainers team can merge.
+
+1. **CodeRabbit** reviews automatically when the PR is opened. Resolve every thread it raises — unresolved threads (even outdated ones) block the next step. If it reports "Review rate limited" (quota exhausted), trigger it later by commenting `@coderabbitai full review` on the PR.
+
+2. **Run `/pr-review-merge <PR number>`** from Claude Code inside this repo. This is the second, judgment-based review plus triage: it checks the gates (CodeRabbit reviewed, threads resolved, CI green, real PR description, no credential-shaped files, lockfile changes explained), reviews the diff, and routes the PR with a label and a team review request:
+
+   - `ready-for-maintainer-review` — nothing sensitive touched; any maintainer can approve and merge.
+   - `needs-senior-review` — the diff touches sensitive paths (the API contract (`ajax.ts`, `remoteRoutes`, `types.ts`), auth/session code, login flows, capability-gated routing, deploy workflows); the Senior Engineering team must review first.
+
+   The full gate and sensitive-path list lives in [`.claude/skills/pr-review-merge/SKILL.md`](./.claude/skills/pr-review-merge/SKILL.md). The skill never approves or merges anything.
+
+3. **A maintainer approves and merges** in the GitHub UI (squash merge). The approval can come from anyone with write access — but not the PR author.
+
+To run the skill you need Claude Code started inside the repo (pull first — the skill ships in `.claude/skills/`), an authenticated `gh` CLI (`gh auth login`), and write access for the labelling step. If you work from a fork, run `gh repo set-default kanzucodefoundation/project-zoe-client` once so `gh` resolves PRs against the upstream repo.
+
+Releases (`develop` → `master`) follow the same process — the skill scans the full cumulative diff and routes it like any other PR. Merging to `master` deploys the production client. If a hotfix ever lands on `master` directly, back-merge it into `develop` immediately, using a merge commit (not squash).
+
 ## Branch naming
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,11 @@ Every PR passes through three layers before it can merge. `develop` and `master`
 
    The full gate and sensitive-path list lives in [`.claude/skills/pr-review-merge/SKILL.md`](./.claude/skills/pr-review-merge/SKILL.md). The skill never approves or merges anything.
 
-3. **A maintainer approves and merges** in the GitHub UI (squash merge). The approval can come from anyone with write access — but not the PR author.
+3. **A maintainer approves and merges** in the GitHub UI (squash merge). Both the approval and the merge require Maintainer membership — the PR author may not approve their own PR.
 
 To run the skill you need Claude Code started inside the repo (pull first — the skill ships in `.claude/skills/`), an authenticated `gh` CLI (`gh auth login`), and write access for the labelling step. If you work from a fork, run `gh repo set-default kanzucodefoundation/project-zoe-client` once so `gh` resolves PRs against the upstream repo.
 
-Releases (`develop` → `master`) follow the same process — the skill scans the full cumulative diff and routes it like any other PR. Merging to `master` deploys the production client. If a hotfix ever lands on `master` directly, back-merge it into `develop` immediately, using a merge commit (not squash).
+Releases (`develop` → `master`) follow the same process with one exception: the CodeRabbit-reviewed gate (gate 1) is waived for release PRs — CodeRabbit may report "Review skipped" on the release PR itself, and that is acceptable. All other gates still apply in full, including unresolved threads, CI green, non-trivial description, no credential-shaped files, and lockfile explained. This exception applies only to a PR with head `develop` targeting `master`; a PR from any other branch targeting `master` is not a release PR and must satisfy every gate including gate 1. Merging to `master` deploys the production client. If a hotfix ever lands on `master` directly, back-merge it into `develop` immediately, using a merge commit (not squash).
 
 ## Branch naming
 


### PR DESCRIPTION
# Summary of changes
Adds a **PR review & merge** section to `CONTRIBUTING.md` covering the workflow now in force: CodeRabbit first pass → `/pr-review-merge` second pass and triage (the two labels and which team reviews what) → maintainer approval and merge, plus the branch-protection rules, prerequisites for running the skill, the `@coderabbitai full review` quota fallback, and release/back-merge conventions. Sensitive-path examples adapted to the client (`ajax.ts`/`remoteRoutes`/`types.ts` API contract, auth/session code, login flows, capability-gated routing).

# How should this be tested?
- Docs only. Read it as a new contributor would.

# Notes for reviewers
- Companion to kanzucodefoundation/project-zoe-server#254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the pull request review and merge process.
  * Documented protected-branch requirements, required approvals, CI checks, review routing, and merge permissions.
  * Added instructions for resolving review feedback and handling changes involving sensitive areas.
  * Documented release-specific review exceptions and required hotfix back-merges.
  * Clarified prerequisites for using the automated review and merge workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->