### PR TITLE
feat(tasks): scope task assignee pickers to location instead of all users

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -150,6 +150,8 @@ export const remoteRoutes = {
   tags: `${apiBaseUrl}/api/tags`,
   users: `${apiBaseUrl}/api/users`,
   userGroups: `${apiBaseUrl}/api/user-groups`,
+  usersByLocation: `${apiBaseUrl}/api/users/by-location`,
+  contactLocationGroup: `${apiBaseUrl}/api/groups/contact-location`,
   roles: `${apiBaseUrl}/api/user-roles`,
   contactsPhone: `${apiBaseUrl}/api/crm/phones`,
   contactsAddress: `${apiBaseUrl}/api/crm/addresses`,

--- a/src/modules/tasks/AssignTaskDialog.tsx
+++ b/src/modules/tasks/AssignTaskDialog.tsx
@@ -18,13 +18,7 @@ import { remoteRoutes } from '../../data/constants';
 import { taskApi } from './api';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
-import type { Task } from '../../utils/types';
-
-interface UserOption {
-  id: number;
-  username: string;
-  fullName: string;
-}
+import { extractUsersByLocation, type Task, type UserOption } from '../../utils/types';
 
 interface Props {
   task: Task | null;
@@ -49,8 +43,9 @@ export default function AssignTaskDialog({
   useEffect(() => {
     if (!open) return;
     const locationGroupId = task?.locationGroup?.id;
+    setUsers([]); 
+    setSelectedUser(null); 
     if (!locationGroupId) {
-      setUsers([]);
       setUsersLoading(false);
       return;
     }
@@ -61,8 +56,7 @@ export default function AssignTaskDialog({
       .get(`${remoteRoutes.usersByLocation}/${locationGroupId}`)
       .then((r) => {
         if (ignore) return;
-        const list = Array.isArray(r.data) ? r.data : r.data?.data ?? [];
-        setUsers(list);
+        setUsers(extractUsersByLocation(r));
       })
       .catch(() => {
         if (!ignore) setUsers([]);
@@ -168,7 +162,7 @@ export default function AssignTaskDialog({
             getOptionLabel={(u) => u.fullName || u.username}
             value={selectedUser}
             loading={usersLoading}
-            disabled={noLocationGroup}
+            disabled={noLocationGroup || usersLoading}
             onChange={(_, val) => setSelectedUser(val)}
             renderInput={(params) => (
               <TextField

--- a/src/modules/tasks/AssignTaskDialog.tsx
+++ b/src/modules/tasks/AssignTaskDialog.tsx
@@ -41,20 +41,40 @@ export default function AssignTaskDialog({
 }: Props) {
   const qc = useQueryClient();
   const [users, setUsers] = useState<UserOption[]>([]);
+  const [usersLoading, setUsersLoading] = useState(false);
   const [selectedUser, setSelectedUser] = useState<UserOption | null>(null);
   const [comment, setComment] = useState('');
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
+    if (!open) return;
+    const locationGroupId = task?.locationGroup?.id;
+    if (!locationGroupId) {
+      setUsers([]);
+      setUsersLoading(false);
+      return;
+    }
+
+    let ignore = false;
+    setUsersLoading(true);
     ajax
-      .get(remoteRoutes.users)
+      .get(`${remoteRoutes.usersByLocation}/${locationGroupId}`)
       .then((r) => {
+        if (ignore) return;
         const list = Array.isArray(r.data) ? r.data : r.data?.data ?? [];
         setUsers(list);
       })
-      .catch(() => setUsers([]));
-  }, []);
+      .catch(() => {
+        if (!ignore) setUsers([]);
+      })
+      .finally(() => {
+        if (!ignore) setUsersLoading(false);
+      });
 
+    return () => {
+      ignore = true;
+    };
+  }, [open, task?.locationGroup?.id]);
   useEffect(() => {
     if (!open) {
       setSelectedUser(null);
@@ -85,6 +105,7 @@ export default function AssignTaskDialog({
   const contactName = task?.contact?.person
     ? `${task.contact.person.firstName} ${task.contact.person.lastName}`
     : undefined;
+  const noLocationGroup = open && !task?.locationGroup?.id;
 
   return (
     <Dialog
@@ -146,14 +167,31 @@ export default function AssignTaskDialog({
             options={users}
             getOptionLabel={(u) => u.fullName || u.username}
             value={selectedUser}
+            loading={usersLoading}
+            disabled={noLocationGroup}
             onChange={(_, val) => setSelectedUser(val)}
             renderInput={(params) => (
               <TextField
                 {...params}
                 label="Assign to"
-                placeholder="Select a team member"
+                placeholder={
+                  noLocationGroup
+                    ? 'No location assigned to this contact yet'
+                    : 'Select a team member'
+                }
                 required
                 size="small"
+                InputProps={{
+                  ...params.InputProps,
+                  endAdornment: (
+                    <>
+                      {usersLoading ? (
+                        <CircularProgress color="inherit" size={16} />
+                      ) : null}
+                      {params.InputProps.endAdornment}
+                    </>
+                  ),
+                }}
               />
             )}
           />

--- a/src/modules/tasks/CreateTaskDialog.tsx
+++ b/src/modules/tasks/CreateTaskDialog.tsx
@@ -24,21 +24,16 @@ import { useState, useEffect } from 'react';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { useCreateTask } from './hooks';
-import { TaskType, TYPE_LABELS, type Task } from '../../utils/types';
+import { TaskType, TYPE_LABELS, extractUsersByLocation, type Task, type UserOption } from '../../utils/types';
 import ajax from '../../utils/ajax';
 import { remoteRoutes } from '../../data/constants';
+import { toast } from 'react-toastify';
 
 interface Props {
   open: boolean;
   contactId: number;
   onClose: () => void;
   onSuccess: (task: Task) => void;
-}
-
-interface UserOption {
-  id: number;
-  username: string;
-  fullName: string;
 }
 
 const TYPE_ICONS: Record<TaskType, React.ReactNode> = {
@@ -83,12 +78,12 @@ export default function CreateTaskDialog({
         const usersRes = await ajax.get(
           `${remoteRoutes.usersByLocation}/${locationGroup.id}`,
         );
-        const list = Array.isArray(usersRes.data)
-          ? usersRes.data
-          : usersRes.data?.data ?? [];
-        if (!ignore) setUsers(list);
+        if (!ignore) setUsers(extractUsersByLocation(usersRes));
       } catch {
-        if (!ignore) setUsers([]);
+        if (!ignore) {
+          setUsers([]);
+          toast.error('Failed to load assignable users');
+        }
       } finally {
         if (!ignore) setUsersLoading(false);
       }

--- a/src/modules/tasks/CreateTaskDialog.tsx
+++ b/src/modules/tasks/CreateTaskDialog.tsx
@@ -10,6 +10,7 @@ import {
   Stack,
   CircularProgress,
   Autocomplete,
+  Typography,
   useMediaQuery,
   useTheme,
 } from '@mui/material';
@@ -56,19 +57,48 @@ export default function CreateTaskDialog({
   const theme = useTheme();
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
   const [users, setUsers] = useState<UserOption[]>([]);
+  const [usersLoading, setUsersLoading] = useState(false);
+  const [noLocationGroup, setNoLocationGroup] = useState(false);
   const createTask = useCreateTask(contactId);
 
   useEffect(() => {
-    if (open) {
-      ajax
-        .get(remoteRoutes.users)
-        .then((r) => {
-          const list = Array.isArray(r.data) ? r.data : r.data?.data ?? [];
-          setUsers(list);
-        })
-        .catch(() => setUsers([]));
-    }
-  }, [open]);
+    if (!open) return;
+
+    let ignore = false;
+    const loadAssignableUsers = async () => {
+      setUsersLoading(true);
+      setNoLocationGroup(false);
+      setUsers([]);
+      try {
+        const locRes = await ajax.get(
+          `${remoteRoutes.contactLocationGroup}/${contactId}`,
+        );
+        const locationGroup = locRes.data as { id: number; name: string } | null;
+
+        if (!locationGroup) {
+          if (!ignore) setNoLocationGroup(true);
+          return;
+        }
+
+        const usersRes = await ajax.get(
+          `${remoteRoutes.usersByLocation}/${locationGroup.id}`,
+        );
+        const list = Array.isArray(usersRes.data)
+          ? usersRes.data
+          : usersRes.data?.data ?? [];
+        if (!ignore) setUsers(list);
+      } catch {
+        if (!ignore) setUsers([]);
+      } finally {
+        if (!ignore) setUsersLoading(false);
+      }
+    };
+
+    loadAssignableUsers();
+    return () => {
+      ignore = true;
+    };
+  }, [open, contactId]);
 
   const formik = useFormik({
     initialValues: {
@@ -148,13 +178,40 @@ export default function CreateTaskDialog({
             <Autocomplete
               options={users}
               getOptionLabel={(u) => u.fullName}
+              loading={usersLoading}
+              disabled={noLocationGroup}
               onChange={(_, val) =>
                 formik.setFieldValue('assignedToId', val?.id ?? null)
               }
               renderInput={(params) => (
-                <TextField {...params} label="Assign to (optional)" />
+                <TextField
+                  {...params}
+                  label="Assign to (optional)"
+                  placeholder={
+                    noLocationGroup
+                      ? 'No location assigned to this contact yet'
+                      : 'Select a team member'
+                  }
+                  InputProps={{
+                    ...params.InputProps,
+                    endAdornment: (
+                      <>
+                        {usersLoading ? (
+                          <CircularProgress color="inherit" size={16} />
+                        ) : null}
+                        {params.InputProps.endAdornment}
+                      </>
+                    ),
+                  }}
+                />
               )}
             />
+            {noLocationGroup && (
+              <Typography variant="caption" color="text.secondary">
+                This contact isn't in a location group yet, so there's no one
+                to suggest as an assignee.
+              </Typography>
+            )}
 
             <DatePicker
               label="Due date (optional)"

--- a/src/modules/tasks/CreateTaskDialog.tsx
+++ b/src/modules/tasks/CreateTaskDialog.tsx
@@ -64,6 +64,7 @@ export default function CreateTaskDialog({
       setUsersLoading(true);
       setNoLocationGroup(false);
       setUsers([]);
+      formik.setFieldValue('assignedToId', null);
       try {
         const locRes = await ajax.get(
           `${remoteRoutes.contactLocationGroup}/${contactId}`,
@@ -173,6 +174,7 @@ export default function CreateTaskDialog({
             <Autocomplete
               options={users}
               getOptionLabel={(u) => u.fullName}
+              value={users.find((u) => u.id === formik.values.assignedToId) ?? null}
               loading={usersLoading}
               disabled={noLocationGroup}
               onChange={(_, val) =>

--- a/src/modules/tasks/TaskDrawer.tsx
+++ b/src/modules/tasks/TaskDrawer.tsx
@@ -90,15 +90,31 @@ export default function TaskDrawer({
   }, [task?.id]);
 
   useEffect(() => {
+    const locationGroupId = localTask?.locationGroup?.id;
+    if (!locationGroupId) {
+      setUsers([]);
+      return;
+    }
+    let ignore = false;
     ajax
-      .get(remoteRoutes.users)
+      .get(`${remoteRoutes.usersByLocation}/${locationGroupId}`)
       .then((r) => {
+        if (ignore) return;
         const list = Array.isArray(r.data) ? r.data : r.data?.data ?? [];
-        setUsers(list);
+        const merged =
+          localTask?.assignedTo &&
+          !list.some((u: UserOption) => u.id === localTask.assignedTo?.id)
+            ? [...list, localTask.assignedTo as UserOption]
+            : list;
+        setUsers(merged);
       })
-      .catch(() => setUsers([]));
-  }, []);
-
+      .catch(() => {
+        if (!ignore) setUsers([]);
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [localTask?.locationGroup?.id]);
   if (!localTask) return null;
 
   const isClosed = CLOSED_STATUSES.includes(localTask.status);

--- a/src/modules/tasks/TaskDrawer.tsx
+++ b/src/modules/tasks/TaskDrawer.tsx
@@ -67,6 +67,7 @@ export default function TaskDrawer({
   const [attachLabel, setAttachLabel] = useState('');
   const [localTask, setLocalTask] = useState<Task | null>(task);
   const [usersLoading, setUsersLoading] = useState(false);
+  const [noLocationGroup, setNoLocationGroup] = useState(false);
 
   const reassign = useReassignTask();
   const addComment = useAddComment(localTask?.id ?? 0, contactId);
@@ -91,9 +92,11 @@ export default function TaskDrawer({
       : [];
     setUsers(currentAssignee);
     if (!locationGroupId) {
+      setNoLocationGroup(true);
       setUsersLoading(false);
       return;
     }
+    setNoLocationGroup(false);
     let ignore = false;
     setUsersLoading(true);
     ajax
@@ -117,7 +120,7 @@ export default function TaskDrawer({
     return () => {
       ignore = true;
     };
-  }, [localTask?.locationGroup?.id]);
+  }, [localTask?.locationGroup?.id, localTask?.assignedTo?.id]);
   if (!localTask) return null;
 
   const isClosed = CLOSED_STATUSES.includes(localTask.status);
@@ -298,16 +301,35 @@ export default function TaskDrawer({
             options={users}
             getOptionLabel={(u) => u.fullName}
             value={users.find((u) => u.id === localTask.assignedTo?.id) ?? null}
-            disabled={isClosed || !canEditTaskData || usersLoading}
+            disabled={isClosed || !canEditTaskData || usersLoading || noLocationGroup || reassign.isPending}
             onChange={(_, val) => {
               if (val && canEditTaskData) {
-                reassign.mutate({ id: localTask.id, assignedToId: val.id });
+                reassign.mutate(
+                  { id: localTask.id, assignedToId: val.id },
+                  {
+                    onSuccess: (updated) => {
+                      setLocalTask(updated);
+                      onTaskUpdated(updated);
+                    },
+                  },
+                );
               }
             }}
             renderInput={(params) => (
-              <TextField {...params} size="small" placeholder="Unassigned" />
+              <TextField
+                {...params}
+                size="small"
+                placeholder={
+                  noLocationGroup ? 'No location assigned yet' : 'Unassigned'
+                }
+              />
             )}
           />
+          {noLocationGroup && (
+            <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
+              This contact isn't in a location group yet, so there's no one to suggest as an assignee.
+            </Typography>
+          )}
         </Box>
 
         {/* Due date */}

--- a/src/modules/tasks/TaskDrawer.tsx
+++ b/src/modules/tasks/TaskDrawer.tsx
@@ -27,7 +27,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import TaskStatusChip from './TaskStatusChip';
 import UpdateStatusDialog from './UpdateStatusDialog';
 import { useReassignTask, useAddComment } from './hooks';
-import { CLOSED_STATUSES, extractUsersByLocation, type Task, type UserOption } from '../../utils/types';
+import { CLOSED_STATUSES, extractUsersByLocation, toUserOption, type Task, type UserOption } from '../../utils/types';
 import { taskApi } from './api';
 import { useQueryClient } from '@tanstack/react-query';
 import { taskKeys } from './hooks';
@@ -86,7 +86,10 @@ export default function TaskDrawer({
 
   useEffect(() => {
     const locationGroupId = localTask?.locationGroup?.id;
-    setUsers([]);
+    const currentAssignee = localTask?.assignedTo
+      ? [toUserOption(localTask.assignedTo)]
+      : [];
+    setUsers(currentAssignee);
     if (!locationGroupId) {
       setUsersLoading(false);
       return;
@@ -101,12 +104,12 @@ export default function TaskDrawer({
         const merged =
           localTask?.assignedTo &&
           !list.some((u) => u.id === localTask.assignedTo?.id)
-            ? [...list, localTask.assignedTo as unknown as UserOption]
+            ? [...list, toUserOption(localTask.assignedTo)]
             : list;
         setUsers(merged);
       })
       .catch(() => {
-        if (!ignore) setUsers([]);
+        if (!ignore) setUsers(currentAssignee);
       })
       .finally(() => {
         if (!ignore) setUsersLoading(false);

--- a/src/modules/tasks/TaskDrawer.tsx
+++ b/src/modules/tasks/TaskDrawer.tsx
@@ -27,7 +27,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import TaskStatusChip from './TaskStatusChip';
 import UpdateStatusDialog from './UpdateStatusDialog';
 import { useReassignTask, useAddComment } from './hooks';
-import { CLOSED_STATUSES, type Task } from '../../utils/types';
+import { CLOSED_STATUSES, extractUsersByLocation, type Task, type UserOption } from '../../utils/types';
 import { taskApi } from './api';
 import { useQueryClient } from '@tanstack/react-query';
 import { taskKeys } from './hooks';
@@ -43,12 +43,6 @@ interface Props {
   onClose: () => void;
   onTaskUpdated: (updated: Task) => void;
   contactId?: number;
-}
-
-interface UserOption {
-  id: number;
-  username: string;
-  fullName: string;
 }
 
 const IMAGE_EXTS = ['.jpg', '.jpeg', '.png', '.webp', '.gif'];
@@ -72,6 +66,7 @@ export default function TaskDrawer({
   const [attachUrl, setAttachUrl] = useState('');
   const [attachLabel, setAttachLabel] = useState('');
   const [localTask, setLocalTask] = useState<Task | null>(task);
+  const [usersLoading, setUsersLoading] = useState(false);
 
   const reassign = useReassignTask();
   const addComment = useAddComment(localTask?.id ?? 0, contactId);
@@ -91,25 +86,30 @@ export default function TaskDrawer({
 
   useEffect(() => {
     const locationGroupId = localTask?.locationGroup?.id;
+    setUsers([]);
     if (!locationGroupId) {
-      setUsers([]);
+      setUsersLoading(false);
       return;
     }
     let ignore = false;
+    setUsersLoading(true);
     ajax
       .get(`${remoteRoutes.usersByLocation}/${locationGroupId}`)
       .then((r) => {
         if (ignore) return;
-        const list = Array.isArray(r.data) ? r.data : r.data?.data ?? [];
+        const list = extractUsersByLocation(r);
         const merged =
           localTask?.assignedTo &&
-          !list.some((u: UserOption) => u.id === localTask.assignedTo?.id)
-            ? [...list, localTask.assignedTo as UserOption]
+          !list.some((u) => u.id === localTask.assignedTo?.id)
+            ? [...list, localTask.assignedTo as unknown as UserOption]
             : list;
         setUsers(merged);
       })
       .catch(() => {
         if (!ignore) setUsers([]);
+      })
+      .finally(() => {
+        if (!ignore) setUsersLoading(false);
       });
     return () => {
       ignore = true;
@@ -295,7 +295,7 @@ export default function TaskDrawer({
             options={users}
             getOptionLabel={(u) => u.fullName}
             value={users.find((u) => u.id === localTask.assignedTo?.id) ?? null}
-            disabled={isClosed || !canEditTaskData}
+            disabled={isClosed || !canEditTaskData || usersLoading}
             onChange={(_, val) => {
               if (val && canEditTaskData) {
                 reassign.mutate({ id: localTask.id, assignedToId: val.id });

--- a/src/modules/tasks/TaskQueue.tsx
+++ b/src/modules/tasks/TaskQueue.tsx
@@ -20,7 +20,7 @@ import {
   type GridPaginationModel,
 } from '@mui/x-data-grid';
 import dayjs from 'dayjs';
-import { useLocationScopedTasks } from './hooks';
+import { useLocationScopedTasks, useMyLocationGroups } from './hooks';
 import TaskStatusChip from './TaskStatusChip';
 import TaskDrawer from './TaskDrawer';
 import TaskCard from './TaskCard';
@@ -29,19 +29,21 @@ import {
   TaskType,
   STATUS_LABELS,
   TYPE_LABELS,
+  extractUsersByLocation,
   type Task,
   type TaskFilters,
+  type UserOption,
 } from '../../utils/types';
 import { remoteRoutes } from '../../data/constants';
 import ajax from '../../utils/ajax';
 
-interface UserOption {
-  id: number | 'unassigned';
-  username: string;
-  fullName: string;
-}
+// UserOption.id is a plain `number` everywhere else (e.g. TaskDrawer's
+// reassign mutation expects a real user id). This queue's filter also needs
+// an "Unassigned" pseudo-option, so widen the id just for this local usage
+// rather than the shared type.
+type AssignableUser = Omit<UserOption, 'id'> & { id: number | 'unassigned' };
 
-const UNASSIGNED: UserOption = {
+const UNASSIGNED: AssignableUser = {
   id: 'unassigned',
   username: 'Unassigned',
   fullName: 'Unassigned',
@@ -52,23 +54,53 @@ export default function TaskQueue() {
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [statusFilter, setStatusFilter] = useState<TaskStatus[]>([]);
   const [typeFilter, setTypeFilter] = useState<TaskType[]>([]);
-  const [assignedTo, setAssignedTo] = useState<UserOption | null>(null);
+  const [assignedTo, setAssignedTo] = useState<AssignableUser | null>(null);
   const [pagination, setPagination] = useState<GridPaginationModel>({
     page: 0,
     pageSize: 20,
   });
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
-  const [users, setUsers] = useState<UserOption[]>([UNASSIGNED]);
+  const [users, setUsers] = useState<AssignableUser[]>([UNASSIGNED]);
+  const [usersLoading, setUsersLoading] = useState(false);
+  const [noLocationGroup, setNoLocationGroup] = useState(false);
+
+  const { data: locationGroupIds = [], isLoading: locationGroupsLoading } =
+    useMyLocationGroups();
 
   useEffect(() => {
-    ajax
-      .get(remoteRoutes.users)
-      .then((r) => {
-        const list = Array.isArray(r.data) ? r.data : r.data?.data ?? [];
-        setUsers([UNASSIGNED, ...list]);
+    if (locationGroupsLoading) return;
+    if (locationGroupIds.length === 0) {
+      setNoLocationGroup(true);
+      setUsers([UNASSIGNED]);
+      setAssignedTo(null);
+      setUsersLoading(false);
+      return;
+    }    setNoLocationGroup(false);
+    let ignore = false;
+    setUsersLoading(true);
+    Promise.all(
+      locationGroupIds.map((id) =>
+        ajax
+          .get(`${remoteRoutes.usersByLocation}/${id}`)
+          .then(extractUsersByLocation)
+          .catch(() => []),
+      ),
+    )
+      .then((results) => {
+        if (ignore) return;
+        const merged = results.flat();
+        const deduped = Array.from(
+          new Map(merged.map((u) => [u.id, u])).values(),
+        );
+        setUsers([UNASSIGNED, ...deduped]);
       })
-      .catch(() => {});
-  }, []);
+      .finally(() => {
+        if (!ignore) setUsersLoading(false);
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [locationGroupIds, locationGroupsLoading]);
 
   const filters: TaskFilters = {
     ...(statusFilter.length > 0 && { status: statusFilter }),
@@ -216,13 +248,21 @@ export default function TaskQueue() {
               options={users}
               getOptionLabel={(u) => u.fullName}
               value={assignedTo}
+              disabled={usersLoading || noLocationGroup}
               onChange={(_, val) => {
                 setAssignedTo(val);
                 setPagination((p) => ({ ...p, page: 0 }));
               }}
               sx={{ width: { xs: '100%', sm: 240 } }}
               renderInput={(params) => (
-                <TextField {...params} label="Assigned to" size="small" />
+                <TextField
+                  {...params}
+                  label="Assigned to"
+                  size="small"
+                  placeholder={
+                    noLocationGroup ? 'No locations assigned' : undefined
+                  }
+                />
               )}
             />
             {hasFilters && (

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -214,3 +214,17 @@ export interface TaskFilters {
   page?: number;
   limit?: number;
 }
+
+export interface UserOption {
+  id: number;
+  username: string;
+  fullName: string;
+}
+
+export type UsersByLocationResponse = UserOption[] | { data: UserOption[] };
+
+export function extractUsersByLocation(
+  res: { data: UsersByLocationResponse },
+): UserOption[] {
+  return Array.isArray(res.data) ? res.data : res.data.data;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -228,3 +228,12 @@ export function extractUsersByLocation(
 ): UserOption[] {
   return Array.isArray(res.data) ? res.data : res.data.data;
 }
+
+export function toUserOption(u: TaskUser): UserOption {
+  const person = u.contact?.person;
+  return {
+    id: u.id,
+    username: u.username,
+    fullName: person ? `${person.firstName} ${person.lastName}` : u.username,
+  };
+}


### PR DESCRIPTION
## Summary of changes
- Added `usersByLocation` and `contactLocationGroup` base routes to   `constants.ts` (base paths only; ids appended at call sites, no   `:param` placeholders in the constant itself).
- `CreateTaskDialog`: resolves the contact's location group via   `contactLocationGroup/:contactId`, then fetches assignable users via  `usersByLocation/:groupId`. Shows a friendly empty state ("no location assigned yet") instead of an empty silent dropdown when a  contact has no location group.
- `TaskDrawer` and `AssignTaskDialog`: fetch assignable users via  `usersByLocation/:groupId` using `task.locationGroup.id`, guarded so   the request is never fired with an undefined/missing id.

## How should this be tested
1. Open a contact that belongs to a location group → "New Task" →    confirm the assignee dropdown only shows users tied to that  location (and, per the paired server change, its FOB leaders).
2. Open an existing task for that same contact → open the Assign Task    dialog and the task drawer's "Assigned To" field → confirm the same   scoped list appears, with no `/by-location/undefined` request and   no 400.
3. Open a contact/task with **no** location group → confirm the   dropdown shows the "no location" empty state instead of throwing   or silently showing nothing.
4. Confirm assigning a user still calls the existing   reassign/create/update task flows unchanged (no regression in   `taskApi` usage).

## Note for reviewers
- This depends on the paired server PR merging first — without it,  `usersByLocation`/`contactLocationGroup` will 404, and the dropdowns  will just show empty state, not crash.

## Out of scope
- `TaskQueue`'s "Assigned to" filter dropdown is intentionally left  showing all users — a manager filtering the whole queue may want to  filter across locations, not just one.
- No visual distinction in the dropdown between a location member and  a FOB leader (e.g. no badge) — possible follow-up, not part of this  PR.
- No caching/memoization of the location-group or user lookups across  dialogs opening repeatedly for the same contact/task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task assignment suggestions now load users based on the relevant location group.
  * Assignment filters can combine users from all available location groups.
  * Loading indicators and contextual guidance clarify suggestion availability.
* **Bug Fixes**
  * Assignee selection is disabled when data is loading, unavailable, or reassignment is in progress.
  * The current assignee remains available even when absent from refreshed suggestions.
  * Failed user loading now displays an error message.
* **Refactor**
  * Shared user-option normalization provides consistent assignment results across task views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->