### PR TITLE
fix(tasks): stabilize locationGroupIds default and fix ajax call shape in TaskQueue

### DIFF
--- a/src/modules/tasks/TaskQueue.tsx
+++ b/src/modules/tasks/TaskQueue.tsx
@@ -49,6 +49,11 @@ const UNASSIGNED: AssignableUser = {
   fullName: 'Unassigned',
 };
 
+// Stable reference so the effect below doesn't re-run every render when
+// useMyLocationGroups has no cached data yet (default `[]` would otherwise
+// be a new array on each render).
+const EMPTY_LOCATION_GROUP_IDS: number[] = [];
+
 export default function TaskQueue() {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -64,7 +69,7 @@ export default function TaskQueue() {
   const [usersLoading, setUsersLoading] = useState(false);
   const [noLocationGroup, setNoLocationGroup] = useState(false);
 
-  const { data: locationGroupIds = [], isLoading: locationGroupsLoading } =
+  const { data: locationGroupIds = EMPTY_LOCATION_GROUP_IDS, isLoading: locationGroupsLoading } =
     useMyLocationGroups();
 
   useEffect(() => {
@@ -75,14 +80,15 @@ export default function TaskQueue() {
       setAssignedTo(null);
       setUsersLoading(false);
       return;
-    }    setNoLocationGroup(false);
+    }
+    setNoLocationGroup(false);
     let ignore = false;
     setUsersLoading(true);
     Promise.all(
       locationGroupIds.map((id) =>
         ajax
           .get(`${remoteRoutes.usersByLocation}/${id}`)
-          .then(extractUsersByLocation)
+          .then((r) => extractUsersByLocation(r))
           .catch(() => []),
       ),
     )
@@ -248,7 +254,7 @@ export default function TaskQueue() {
               options={users}
               getOptionLabel={(u) => u.fullName}
               value={assignedTo}
-              disabled={usersLoading || noLocationGroup}
+              disabled={usersLoading || locationGroupsLoading || noLocationGroup}
               onChange={(_, val) => {
                 setAssignedTo(val);
                 setPagination((p) => ({ ...p, page: 0 }));


### PR DESCRIPTION
## Summary of changes
 
- Replaced the inline `data: locationGroupIds = []` default with a stable, module-level `EMPTY_LOCATION_GROUP_IDS` constant so the effect fetching users doesn't get a new array reference (and therefore doesn't re-fire) on every render when the location groups query has no data yet.
- Changed `.then(extractUsersByLocation)` to `.then((r) => extractUsersByLocation(r))` in the per-location user fetch, matching the exact call shape already used successfully in `TaskDrawer` against the same `usersByLocation` endpoint, to avoid the ajax call-shape ambiguity flagged by CodeRabbit.
## How should this be tested
 
- Load the Task Queue page and confirm the "Assigned to" filter still populates with users scoped to the current user's location groups (not the full user list).
- Confirm selecting a user in the filter still correctly filters the task list.

## Out of scope
 
- Auditing/fixing `ajax` usage in `hooks.ts` and `AssignTaskDialog.tsx`.
- Any change to the shared `UserOption` type in `utils/types.ts` (reverted to strict `number` id; the `'unassigned'` case is handled locally in `TaskQueue.tsx` via `AssignableUser`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task assignment behavior when location groups are unavailable or still loading.
  * Prevented unnecessary refreshes during task queue updates.
  * Disabled assignee suggestions while location group data is loading to avoid incomplete results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->