### PR TITLE
minor ui updates in darkmode

### DIFF
--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -843,7 +843,7 @@ const ReportSubmissionForm = () => {
 
       return (
         <FormControl fullWidth error={hasError} component="fieldset">
-          <FormLabel component="legend">
+          <FormLabel component="legend" sx={{'&.Mui-focused': { color: 'text.secondary' },}}>
             {field.label}
             {field.required ? ' *' : ''}
           </FormLabel>

--- a/src/modules/tasks/UpdateStatusDialog.tsx
+++ b/src/modules/tasks/UpdateStatusDialog.tsx
@@ -180,7 +180,7 @@ export default function UpdateStatusDialog({
         <DialogContent dividers={isPhone}>
           <Stack spacing={3} sx={{ mt: 1 }}>
             <FormControl>
-              <FormLabel>New Status</FormLabel>
+              <FormLabel sx={{color:'text.primary'}}>New Status</FormLabel>
               <RadioGroup
                 value={formik.values.status}
                 onChange={(e) => formik.setFieldValue('status', e.target.value)}


### PR DESCRIPTION
# Summary of changes
- Added `sx={{color:'text.primary'}` to the Task status popup to improve visibility of `New Status` text.
- Added `sx={{'&.Mui-focused': { color: 'text.secondary' },}}` to main the text color on focus.

# How should this be tested? 
- Navigate to the tasks page, click on a task to see the task drawer, then click `update status ` to see the update status pop up.
- Confirm that the `new status` text is visible in dark mode.
- Navigate to MC report submission, verify that  `MC Members Present *` maintains its text color and does not dim when a user checks a member.

# Notes for reviewers
- These are just 2 slight color improvements

# Out of scope
-  Anything not explained in the summary of changes is out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved form label appearance when fields are focused.
  * Standardized status selection label colors with the application theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->