### PR TITLE
fix websocket connection console error

### DIFF
--- a/src/data/useNotificationSocket.ts
+++ b/src/data/useNotificationSocket.ts
@@ -19,6 +19,7 @@ export function useNotificationSocket(token: string | null) {
       auth: { token },
       transports: ['websocket', 'polling'],
       tryAllTransports: true,
+      reconnectionAttempts: 5,
       autoConnect: false,
     });
     socketRef.current = socket;
@@ -33,11 +34,6 @@ export function useNotificationSocket(token: string | null) {
 
     socket.on('connect_error', (err) => {
       console.error('Notification socket connection error:', err.message);
-    });
-    socket.io.on('reconnect_attempt', (attempt) => {
-      if (attempt > 5) {
-        socket.disconnect();
-      }
     });
     const connectTimer = setTimeout(() => socket.connect(), 0);
 

--- a/src/data/useNotificationSocket.ts
+++ b/src/data/useNotificationSocket.ts
@@ -17,7 +17,8 @@ export function useNotificationSocket(token: string | null) {
 
     const socket = io(NOTIFICATIONS_SOCKET_URL, {
       auth: { token },
-      transports: ['websocket'],
+      transports: ['websocket', 'polling'],
+      tryAllTransports: true,
       autoConnect: false,
     });
     socketRef.current = socket;
@@ -32,6 +33,11 @@ export function useNotificationSocket(token: string | null) {
 
     socket.on('connect_error', (err) => {
       console.error('Notification socket connection error:', err.message);
+    });
+    socket.io.on('reconnect_attempt', (attempt) => {
+      if (attempt > 5) {
+        socket.disconnect();
+      }
     });
     const connectTimer = setTimeout(() => socket.connect(), 0);
 


### PR DESCRIPTION
# Summary of changes
- Added a `polling` fallback alongside `websocket` in the socket.io client transports config, so notifications degrade gracefully to long-polling instead of failing outright when a WebSocket upgrade is blocked (e.g. by a misconfigured reverse proxy).
- Added a reconnect attempt cap via `socket.io.on('reconnect_attempt', ...)` — after 5 failed attempts, the socket disconnects instead of retrying indefinitely against a dead/unreachable endpoint.
- Kept existing `connect_error` logging in place for visibility into connection failures during development and debugging.

# How should this be tested?
- Run the app locally/staging with the backend reachable — confirm notifications still connect via WebSocket as before (check Network tab: connection type should show `websocket`).
- Confirm existing notification functionality (toast on new notification, unread count updates, list invalidation) still works as expected when the connection succeeds via either transport.

# Notes for reviewers
- `transports: ['websocket', 'polling']` means socket.io will attempt WebSocket first and fall back automatically; this adds slight overhead on initial connection in environments where WebSocket already works fine, but improves robustness where it doesn't.

# Out of scope
- Reverse proxy / infra configuration for WebSocket upgrade support on staging and production (tracked as a separate infra task).
- Surfacing connection failures to the end user via UI (currently only logged to console — could be a follow-up if product wants user-facing feedback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification delivery reliability by supporting both real-time WebSocket connections and polling.
  * Added fallback behavior to try all configured connection methods.
  * Limited reconnection attempts to five after repeated failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->