### PR TITLE
(feat): mca weekly attendance summary 

### DIFF
--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -337,10 +337,10 @@ const Reports = () => {
         </Tabs>
       )}
       {/* MC Attendance for the Week */}
-      {!mcaLoading && mcaSummary?.reportFound && (
+      {!mcaLoading && mcaSummary?.reportFound && (dateRange === '7') &&(
         <Box sx={{marginY:2, backgroundColor: 'text.primary', padding: 2, borderRadius: 1, color: 'background.paper'}}>
           <Typography variant="h5">
-            This Week's MCA Summary - Total: {mcaSummary.total}
+            This Week's Total Fellowship Attendance: {mcaSummary.total}
           </Typography>
         </Box>  
       )}

--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -96,7 +96,7 @@ const Reports = () => {
         setMcaSummary(response);
         setMcaLoading(false);
       },
-      (error: any) => {
+      (error) => {
         console.error('Failed to fetch MCA summary:', error);
         setMcaLoading(false);
       },

--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -342,14 +342,6 @@ const Reports = () => {
           <Typography variant="h5">
             This Week's MCA Summary - Total: {mcaSummary.total}
           </Typography>
-          {mcaSummary.breakdown.length > 0 && (
-            <Box sx={{display:'flex', flexWrap:'wrap', gap:2, marginY:1}}>
-              {mcaSummary.breakdown.map((g) => (
-                <Typography key={g.groupId} variant="body2">
-                  {g.groupName}: {g.total}                </Typography>
-              ))}
-            </Box>
-          )}
         </Box>  
       )}
 

--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -61,6 +61,14 @@ interface TabCache {
   dateRange: DateRange;
 }
 
+interface McaSummary {
+  total: number;
+  breakdown: { groupId: number; groupName: string; total: number }[];
+  weekStart: string;
+  weekEnd: string;
+  reportFound: boolean;
+}
+
 const Reports = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -78,6 +86,22 @@ const Reports = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const [detailsLoading, setDetailsLoading] = useState(false);
   const [submissionDetails, setSubmissionDetails] = useState<SubmissionDetails | null>(null);
+  const [mcaSummary, setMcaSummary] = useState<McaSummary | null>(null);
+  const [mcaLoading, setMcaLoading] = useState(true);
+
+  useEffect(() => {
+    get(
+      `${remoteRoutes.reports}/mca/weekly-summary`,
+      (response: McaSummary) => {
+        setMcaSummary(response);
+        setMcaLoading(false);
+      },
+      (error: any) => {
+        console.error('Failed to fetch MCA summary:', error);
+        setMcaLoading(false);
+      },
+    );
+  }, []);
 
   // Fetch report types on mount
   useEffect(() => {
@@ -311,6 +335,22 @@ const Reports = () => {
             <Tab key={report.id} label={report.name} value={report.id} />
           ))}
         </Tabs>
+      )}
+      {/* MC Attendance for the Week */}
+      {!mcaLoading && mcaSummary?.reportFound && (
+        <Box sx={{marginY:2, backgroundColor: 'text.primary', padding: 2, borderRadius: 1, color: 'background.paper'}}>
+          <Typography variant="h5">
+            This Week's MCA Summary - Total: {mcaSummary.total}
+          </Typography>
+          {mcaSummary.breakdown.length > 0 && (
+            <Box sx={{display:'flex', flexWrap:'wrap', gap:2, marginY:1}}>
+              {mcaSummary.breakdown.map((g) => (
+                <Typography key={g.groupId} variant="body2">
+                  {g.groupName}: {g.total}                </Typography>
+              ))}
+            </Box>
+          )}
+        </Box>  
       )}
 
       {/* Table */}


### PR DESCRIPTION
# Ticket No
- MC Attendance for a Given Week (Critical)

# Summary of changes
- Added a "Weekly MC Attendance" summary block to the Reports page (`Reports.tsx`), shown above the report tabs.
- Displays the current week's total MCA (`Weekly MC Attendance: {total}`) plus a per-group breakdown (e.g. `Love MC: 42`, `Grace MC: 30`) for every group the logged-in user has leadership visibility over — automatically scaling from a single MC leader up to a Zone/Sector leader without any UI branching, since scope is resolved entirely server-side.
- Fetches from the new `GET /api/reports/mca/weekly-summary` endpoint once on mount; independent of which report tab is currently selected, since it's a standalone leadership metric rather than a per-report view.
- The block only renders when `reportFound` is true and loading has completed, so tenants without an MCA-labelled report field simply don't see it (no broken/empty state).
- Removed the earlier client-side, tab-scoped attendance summary (which summed whatever columns were currently displayed in the paginated submissions table) — it's fully superseded by this, and was unreliable since it was capped to the first 20 rows loaded for the active tab and had no group-leadership scoping.

# How should this be tested?
- Log in as a user leading a single MC → confirm "Weekly MC Attendance" shows just that MC's total for the current week, with one breakdown chip/line.
- Log in as a user leading a Location (multiple MCs) → confirm the total sums across those MCs, with one breakdown line per MC.
- Log in as a user leading a Zone/Sector → confirm the total rolls up across every Location/MC beneath them.
- Log in as a user with no leadership groups → confirm the block doesn't show an error, and shows `Weekly MC Attendance: 0` (or is hidden — see note for reviewers below on the current behavior).
- Switch between report tabs → confirm the summary block stays static (doesn't refetch or change) since it's independent of the active tab.).

# Notes for reviewers
- Currently, a user with zero manageable groups still renders the block with `Weekly MC Attendance: 0` rather than hiding it entirely — flagging this as a decision point.
- The summary is intentionally placed above the tabs and fetched independently of `activeTab`/`submissions` state, since product intent was "a leader always sees their current week's MCA regardless of which report they're browsing" rather than a per-tab stat.
- No date-range picker is wired to this block — it always reflects the current Sunday–Saturday week, per product decision, separate from the existing "All Time / 7 days / 30 days" dropdown that still governs the submissions table below it.

# Out of scope
- No changes to the submissions table, download/export, or submission details modal.
- No new week-selector UI — always shows the current week.
- No changes to how report tabs are fetched/rendered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an MCA weekly summary report displaying the weekly total for seven-day date ranges.
  * Added automatic retrieval of the latest weekly summary when the report loads.
* **Bug Fixes**
  * Improved report behavior by handling loading completion and request failures gracefully.
  * Ensured the weekly total appears only after the summary is available and applicable date range is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->