### PR TITLE
feat: show MC leaders who have not submitted report

### DIFF
--- a/src/modules/reports/ComplianceTable.tsx
+++ b/src/modules/reports/ComplianceTable.tsx
@@ -1,0 +1,93 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+  CircularProgress,
+  Box,
+  Tooltip,
+} from '@mui/material';
+import { format, parseISO } from 'date-fns';
+
+export interface ComplianceRow {
+  groupId: number;
+  groupName: string;
+  leaderName: string;
+  weeksInRange: number;
+  weeksMissed: number;
+  missedWeeks: string[];
+  missingCurrentWeek: boolean;
+}
+
+interface Props {
+  rows: ComplianceRow[];
+  loading: boolean;
+  showWeeksMissed?: boolean;
+}
+
+const formatWeek = (isoDate: string): string => format(parseISO(isoDate), 'MMM d');
+
+const ComplianceTable = ({ rows, loading, showWeeksMissed = true }: Props) => {
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" py={6}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <Box textAlign="center" py={6}>
+        <Typography color="textSecondary">
+          All MC leaders have submitted for the selected period
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ backgroundColor: 'primary.paper' }}>
+            <TableCell sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>MC Leader</TableCell>
+            <TableCell sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>MC Group</TableCell>
+            {showWeeksMissed && (
+              <TableCell sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }} align="right">
+                Weeks missed
+              </TableCell>
+            )}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.groupId} hover>
+              <TableCell sx={{ whiteSpace: 'nowrap', py:2 }}>{row.leaderName}</TableCell>
+              <TableCell sx={{ whiteSpace: 'nowrap', py:2  }}>{row.groupName}</TableCell>
+              {showWeeksMissed && (
+                <TableCell align="right">
+                  <Tooltip title={row.missedWeeks.map(formatWeek).join(', ')}>
+                    <Typography
+                      component="span"
+                      variant="body2"
+                      sx={{ py:2, fontWeight:500  }}
+                    >
+                      {row.weeksMissed} / {row.weeksInRange}
+                    </Typography>
+                  </Tooltip>
+                </TableCell>
+              )}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default ComplianceTable;

--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -14,13 +14,14 @@ import {
 } from '@mui/material';
 import { Download as DownloadIcon } from '@mui/icons-material';
 import ExcelJS from 'exceljs';
-import { format, subDays, subWeeks } from 'date-fns';
+import { format, subDays, subWeeks, startOfWeek } from 'date-fns';
 import { toast } from 'react-toastify';
 import { get } from '../../utils/ajax';
 import { remoteRoutes } from '../../data/constants';
 import ReportsTable from './ReportsTable';
 import ComplianceTable, { type ComplianceRow } from './ComplianceTable';
 import SubmissionDetailsModal from './SubmissionDetailsModal';
+import type {Column, SubmissionRow } from '../../utils/types';
 
 interface ReportType {
   id: number;
@@ -29,25 +30,10 @@ interface ReportType {
   fieldCount: number;
 }
 
-interface Column {
-  name: string;
-  label: string;
-}
-
 interface PaginationInfo {
   total: number;
   limit: number;
   offset: number;
-}
-
-// A single submission row as returned by the submissions endpoint. `data`
-// holds the dynamic, report-specific field values keyed by column name.
-interface SubmissionRow {
-  id: number;
-  data: Record<string, unknown>;
-  submittedBy: string | { name: string };
-  submittedAt: string;
-  [key: string]: unknown;
 }
 
 interface SubmissionsResponse {
@@ -89,12 +75,6 @@ interface McaSummary {
   weekEnd: string;
   reportFound: boolean;
 }
-
-// Earliest date the compliance endpoint is asked for when "All Time" is
-// selected. Using an explicit, far-past date (rather than omitting `from`)
-// ensures the backend doesn't silently apply its own lookback cap while the
-// UI still advertises the range as unbounded.
-const COMPLIANCE_EPOCH = '1970-01-01';
 
 // Small helper so we don't spread `any` around every catch handler.
 const getErrorMessage = (error: unknown): string =>
@@ -170,20 +150,29 @@ const Reports = () => {
     return { from, to };
   }, [dateRange]);
 
-  // Compliance is inherently a per-reporting-week concept, so the same
-  // dateRange control is reinterpreted here as "how many reporting weeks
-  // back": 7 days -> current week only, 30 days -> last 4 weeks, all time
-  // -> explicitly go back to COMPLIANCE_EPOCH so the backend doesn't apply
-  // its own (silent) lookback cap while the UI still says "All Time".
-  const getComplianceDateRange = useCallback((): { from: string; to: string } => {
-    const to = format(new Date(), 'yyyy-MM-dd');
+  // Reporting periods are Sunday-start weeks, matching the backend's
+  // getStartOfWeek()/reportingPeriod convention.
+  const getComplianceDateRange = useCallback((): { from?: string; to: string } => {
+    const now = new Date();
+    const to = format(now, 'yyyy-MM-dd');
+    const currentWeekStart = startOfWeek(now, { weekStartsOn: 0 });
+
     if (dateRange === '7') {
-      return { from: to, to };
+      // Current reporting week only.
+      return { from: format(currentWeekStart, 'yyyy-MM-dd'), to };
     }
     if (dateRange === '30') {
-      return { from: format(subWeeks(new Date(), 3), 'yyyy-MM-dd'), to };
+      // Last 4 completed reporting weeks, excluding the current (partial) week.
+      const lastCompletedWeekEnd = subDays(currentWeekStart, 1);
+      const from = subWeeks(currentWeekStart, 4);
+      return {
+        from: format(from, 'yyyy-MM-dd'),
+        to: format(lastCompletedWeekEnd, 'yyyy-MM-dd'),
+      };
     }
-    return { from: COMPLIANCE_EPOCH, to };
+    // All time: omit `from` entirely so the backend applies its own
+    // configured lookback cap, rather than forcing a hardcoded epoch here.
+    return { to };
   }, [dateRange]);
 
   // Fetch submissions when active tab or date range changes
@@ -232,7 +221,8 @@ const Reports = () => {
 
     setLoadingCompliance(true);
     const { from, to } = getComplianceDateRange();
-    const url = `${remoteRoutes.reports}/mc/compliance?to=${to}&from=${from}`;
+    const fromParam = from ? `&from=${from}` : '';
+    const url = `${remoteRoutes.reports}/mc/compliance?to=${to}${fromParam}`;
 
     get(
       url,

--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -40,8 +40,18 @@ interface PaginationInfo {
   offset: number;
 }
 
+// A single submission row as returned by the submissions endpoint. `data`
+// holds the dynamic, report-specific field values keyed by column name.
+interface SubmissionRow {
+  id: number;
+  data: Record<string, unknown>;
+  submittedBy: string | { name: string };
+  submittedAt: string;
+  [key: string]: unknown;
+}
+
 interface SubmissionsResponse {
-  submissions: Record<string, any>[];
+  submissions: SubmissionRow[];
   columns: Column[];
   pagination: PaginationInfo;
 }
@@ -67,7 +77,7 @@ const COMPLIANCE_TAB_ID = 'compliance' as const;
 type ActiveTab = number | typeof COMPLIANCE_TAB_ID | null;
 
 interface TabCache {
-  data: Record<string, any>[];
+  data: SubmissionRow[];
   columns: Column[];
   dateRange: DateRange;
 }
@@ -80,6 +90,16 @@ interface McaSummary {
   reportFound: boolean;
 }
 
+// Earliest date the compliance endpoint is asked for when "All Time" is
+// selected. Using an explicit, far-past date (rather than omitting `from`)
+// ensures the backend doesn't silently apply its own lookback cap while the
+// UI still advertises the range as unbounded.
+const COMPLIANCE_EPOCH = '1970-01-01';
+
+// Small helper so we don't spread `any` around every catch handler.
+const getErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
 const Reports = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -89,7 +109,7 @@ const Reports = () => {
   const [dateRange, setDateRange] = useState<DateRange>('all');
   const [loadingReports, setLoadingReports] = useState(true);
   const [loadingSubmissions, setLoadingSubmissions] = useState(false);
-  const [submissions, setSubmissions] = useState<Record<string, any>[]>([]);
+  const [submissions, setSubmissions] = useState<SubmissionRow[]>([]);
   const [columns, setColumns] = useState<Column[]>([]);
   const [tabCache, setTabCache] = useState<Record<number, TabCache>>({});
   const [complianceRows, setComplianceRows] = useState<ComplianceRow[]>([]);
@@ -109,8 +129,8 @@ const Reports = () => {
         setMcaSummary(response);
         setMcaLoading(false);
       },
-      (error) => {
-        console.error('Failed to fetch MCA summary:', error);
+      (error: unknown) => {
+        console.error('Failed to fetch MCA summary:', getErrorMessage(error));
         setMcaLoading(false);
       },
     );
@@ -128,8 +148,8 @@ const Reports = () => {
         setActiveTab(list.length > 0 ? list[0].id : COMPLIANCE_TAB_ID);
         setLoadingReports(false);
       },
-      (error: any) => {
-        console.error('Failed to fetch reports:', error);
+      (error: unknown) => {
+        console.error('Failed to fetch reports:', getErrorMessage(error));
         toast.error('Failed to load report types');
         setActiveTab(COMPLIANCE_TAB_ID);
         setLoadingReports(false);
@@ -153,8 +173,9 @@ const Reports = () => {
   // Compliance is inherently a per-reporting-week concept, so the same
   // dateRange control is reinterpreted here as "how many reporting weeks
   // back": 7 days -> current week only, 30 days -> last 4 weeks, all time
-  // -> leave 'from' unset and let the backend apply its own lookback cap.
-  const getComplianceDateRange = useCallback((): { from?: string; to: string } => {
+  // -> explicitly go back to COMPLIANCE_EPOCH so the backend doesn't apply
+  // its own (silent) lookback cap while the UI still says "All Time".
+  const getComplianceDateRange = useCallback((): { from: string; to: string } => {
     const to = format(new Date(), 'yyyy-MM-dd');
     if (dateRange === '7') {
       return { from: to, to };
@@ -162,7 +183,7 @@ const Reports = () => {
     if (dateRange === '30') {
       return { from: format(subWeeks(new Date(), 3), 'yyyy-MM-dd'), to };
     }
-    return { to };
+    return { from: COMPLIANCE_EPOCH, to };
   }, [dateRange]);
 
   // Fetch submissions when active tab or date range changes
@@ -194,8 +215,8 @@ const Reports = () => {
         }));
         setLoadingSubmissions(false);
       },
-      (error: any) => {
-        console.error('Failed to fetch submissions:', error);
+      (error: unknown) => {
+        console.error('Failed to fetch submissions:', getErrorMessage(error));
         toast.error('Failed to load submissions');
         setSubmissions([]);
         setColumns([]);
@@ -211,8 +232,7 @@ const Reports = () => {
 
     setLoadingCompliance(true);
     const { from, to } = getComplianceDateRange();
-    const fromParam = from ? `&from=${from}` : '';
-    const url = `${remoteRoutes.reports}/mc/compliance?to=${to}${fromParam}`;
+    const url = `${remoteRoutes.reports}/mc/compliance?to=${to}&from=${from}`;
 
     get(
       url,
@@ -221,9 +241,9 @@ const Reports = () => {
         setComplianceRows(response?.groups || []);
         setLoadingCompliance(false);
       },
-      (error: any) => {
+      (error: unknown) => {
         if (cancelled) return;
-        console.error('Failed to fetch submission compliance:', error);
+        console.error('Failed to fetch submission compliance:', getErrorMessage(error));
         toast.error('Failed to load submission compliance');
         setComplianceRows([]);
         setLoadingCompliance(false);
@@ -239,7 +259,7 @@ const Reports = () => {
     setTabCache({});
   }, [dateRange]);
 
-  const handleRowClick = (row: Record<string, any>) => {
+  const handleRowClick = (row: SubmissionRow) => {
     if (typeof activeTab !== 'number' || !row.id) return;
     setModalOpen(true);
     setDetailsLoading(true);
@@ -251,8 +271,8 @@ const Reports = () => {
         setSubmissionDetails(response);
         setDetailsLoading(false);
       },
-      (error: any) => {
-        console.error('Failed to fetch submission details:', error);
+      (error: unknown) => {
+        console.error('Failed to fetch submission details:', getErrorMessage(error));
         toast.error('Failed to load submission details');
         setDetailsLoading(false);
       },
@@ -281,11 +301,11 @@ const Reports = () => {
     }
 
     const exportData = submissions.map((row) => {
-      const exportRow: Record<string, any> = {};
+      const exportRow: Record<string, string | number> = {};
 
       columns.forEach((col) => {
         const value = row.data?.[col.name];
-        exportRow[col.label] = value ?? '';
+        exportRow[col.label] = (value as string | number) ?? '';
       });
 
       const submittedBy = typeof row.submittedBy === 'object' ? row.submittedBy?.name : row.submittedBy;
@@ -318,8 +338,8 @@ const Reports = () => {
     await exportToExcel(exportData, 'Compliance', fileName);
   };
 
-  const exportToExcel = async (
-    rows: Record<string, any>[],
+  const exportToExcel = async <T extends Record<string, string | number>>(
+    rows: T[],
     sheetName: string,
     fileName: string,
   ) => {

--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -14,11 +14,12 @@ import {
 } from '@mui/material';
 import { Download as DownloadIcon } from '@mui/icons-material';
 import ExcelJS from 'exceljs';
-import { format, subDays } from 'date-fns';
+import { format, subDays, subWeeks } from 'date-fns';
 import { toast } from 'react-toastify';
 import { get } from '../../utils/ajax';
 import { remoteRoutes } from '../../data/constants';
 import ReportsTable from './ReportsTable';
+import ComplianceTable, { type ComplianceRow } from './ComplianceTable';
 import SubmissionDetailsModal from './SubmissionDetailsModal';
 
 interface ReportType {
@@ -53,7 +54,17 @@ interface SubmissionDetails {
   submittedBy: string;
 }
 
+interface ComplianceResponse {
+  weekStarts: string[];
+  groups: ComplianceRow[];
+}
+
 type DateRange = 'all' | '7' | '30' | 'custom';
+
+// Sentinel tab id for the static "Submission Compliance" tab, distinct from
+// the numeric ids of dynamic report types fetched from the API.
+const COMPLIANCE_TAB_ID = 'compliance' as const;
+type ActiveTab = number | typeof COMPLIANCE_TAB_ID | null;
 
 interface TabCache {
   data: Record<string, any>[];
@@ -74,13 +85,15 @@ const Reports = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   const [reports, setReports] = useState<ReportType[]>([]);
-  const [activeTab, setActiveTab] = useState<number | null>(null);
+  const [activeTab, setActiveTab] = useState<ActiveTab>(null);
   const [dateRange, setDateRange] = useState<DateRange>('all');
   const [loadingReports, setLoadingReports] = useState(true);
   const [loadingSubmissions, setLoadingSubmissions] = useState(false);
   const [submissions, setSubmissions] = useState<Record<string, any>[]>([]);
   const [columns, setColumns] = useState<Column[]>([]);
   const [tabCache, setTabCache] = useState<Record<number, TabCache>>({});
+  const [complianceRows, setComplianceRows] = useState<ComplianceRow[]>([]);
+  const [loadingCompliance, setLoadingCompliance] = useState(false);
 
   // Modal state
   const [modalOpen, setModalOpen] = useState(false);
@@ -110,14 +123,15 @@ const Reports = () => {
       (response: any) => {
         const list: ReportType[] = Array.isArray(response) ? response : (response?.reports || []);
         setReports(list);
-        if (list.length > 0) {
-          setActiveTab(list[0].id);
-        }
+        // Fall back to the static Submission Compliance tab when there are
+        // no dynamic report types, rather than leaving activeTab as null.
+        setActiveTab(list.length > 0 ? list[0].id : COMPLIANCE_TAB_ID);
         setLoadingReports(false);
       },
       (error: any) => {
         console.error('Failed to fetch reports:', error);
         toast.error('Failed to load report types');
+        setActiveTab(COMPLIANCE_TAB_ID);
         setLoadingReports(false);
       },
     );
@@ -136,9 +150,24 @@ const Reports = () => {
     return { from, to };
   }, [dateRange]);
 
+  // Compliance is inherently a per-reporting-week concept, so the same
+  // dateRange control is reinterpreted here as "how many reporting weeks
+  // back": 7 days -> current week only, 30 days -> last 4 weeks, all time
+  // -> leave 'from' unset and let the backend apply its own lookback cap.
+  const getComplianceDateRange = useCallback((): { from?: string; to: string } => {
+    const to = format(new Date(), 'yyyy-MM-dd');
+    if (dateRange === '7') {
+      return { from: to, to };
+    }
+    if (dateRange === '30') {
+      return { from: format(subWeeks(new Date(), 3), 'yyyy-MM-dd'), to };
+    }
+    return { to };
+  }, [dateRange]);
+
   // Fetch submissions when active tab or date range changes
   useEffect(() => {
-    if (activeTab === null) return;
+    if (activeTab === null || activeTab === COMPLIANCE_TAB_ID) return;
 
     // Check cache
     const cached = tabCache[activeTab];
@@ -173,15 +202,45 @@ const Reports = () => {
         setLoadingSubmissions(false);
       },
     );
-  }, [activeTab, dateRange, getDateRange]);
+  }, [activeTab, dateRange, getDateRange, tabCache]);
 
+  // Fetch compliance data when the compliance tab (or date range) is active
+  useEffect(() => {
+    if (activeTab !== COMPLIANCE_TAB_ID) return;
+    let cancelled = false;
+
+    setLoadingCompliance(true);
+    const { from, to } = getComplianceDateRange();
+    const fromParam = from ? `&from=${from}` : '';
+    const url = `${remoteRoutes.reports}/mc/compliance?to=${to}${fromParam}`;
+
+    get(
+      url,
+      (response: ComplianceResponse) => {
+        if (cancelled) return;
+        setComplianceRows(response?.groups || []);
+        setLoadingCompliance(false);
+      },
+      (error: any) => {
+        if (cancelled) return;
+        console.error('Failed to fetch submission compliance:', error);
+        toast.error('Failed to load submission compliance');
+        setComplianceRows([]);
+        setLoadingCompliance(false);
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, dateRange, getComplianceDateRange]);
   // Invalidate cache when date range changes
   useEffect(() => {
     setTabCache({});
   }, [dateRange]);
 
   const handleRowClick = (row: Record<string, any>) => {
-    if (!activeTab || !row.id) return;
+    if (typeof activeTab !== 'number' || !row.id) return;
     setModalOpen(true);
     setDetailsLoading(true);
     setSubmissionDetails(null);
@@ -200,29 +259,35 @@ const Reports = () => {
     );
   };
 
-  const handleTabChange = (_: React.SyntheticEvent, newValue: number) => {
+  const handleTabChange = (_: React.SyntheticEvent, newValue: ActiveTab) => {
     setActiveTab(newValue);
   };
 
   const activeReportName = reports.find((r) => r.id === activeTab)?.name || 'Report';
+  const isComplianceTab = activeTab === COMPLIANCE_TAB_ID;
 
   const handleDownload = async () => {
+    if (isComplianceTab) {
+      await downloadCompliance();
+      return;
+    }
+    await downloadSubmissions();
+  };
+
+  const downloadSubmissions = async () => {
     if (submissions.length === 0) {
       toast.warning('No data to export');
       return;
     }
 
-    // Build export data with proper column headers
     const exportData = submissions.map((row) => {
       const exportRow: Record<string, any> = {};
 
-      // Add dynamic columns from report fields
       columns.forEach((col) => {
         const value = row.data?.[col.name];
         exportRow[col.label] = value ?? '';
       });
 
-      // Add metadata columns
       const submittedBy = typeof row.submittedBy === 'object' ? row.submittedBy?.name : row.submittedBy;
       exportRow['Submitted By'] = submittedBy || '';
       exportRow['Submitted At'] = row.submittedAt ? row.submittedAt.slice(0, 10) : '';
@@ -230,19 +295,39 @@ const Reports = () => {
       return exportRow;
     });
 
-    // Create workbook and worksheet
-    const workbook = new ExcelJS.Workbook();
-    const worksheet = workbook.addWorksheet('Submissions');
-    if (exportData.length > 0) {
-      worksheet.columns = Object.keys(exportData[0]).map((key) => ({ header: key, key }));
-      exportData.forEach((row) => worksheet.addRow(row));
-    }
-
-    // Generate filename with report name and date
     const dateStr = format(new Date(), 'yyyy-MM-dd');
     const fileName = `${activeReportName.replace(/\s+/g, '_')}_${dateStr}.xlsx`;
+    await exportToExcel(exportData, 'Submissions', fileName);
+  };
 
-    // Download file
+  const downloadCompliance = async () => {
+    if (complianceRows.length === 0) {
+      toast.warning('No data to export');
+      return;
+    }
+
+    const exportData = complianceRows.map((row) => ({
+      'MC Leader': row.leaderName,
+      'MC Group': row.groupName,
+      'Weeks Missed': `${row.weeksMissed} / ${row.weeksInRange}`,
+      'Missed Weeks': row.missedWeeks.join(', '),
+    }));
+
+    const dateStr = format(new Date(), 'yyyy-MM-dd');
+    const fileName = `MC_Submission_Compliance_${dateStr}.xlsx`;
+    await exportToExcel(exportData, 'Compliance', fileName);
+  };
+
+  const exportToExcel = async (
+    rows: Record<string, any>[],
+    sheetName: string,
+    fileName: string,
+  ) => {
+    const workbook = new ExcelJS.Workbook();
+    const worksheet = workbook.addWorksheet(sheetName);
+    worksheet.columns = Object.keys(rows[0]).map((key) => ({ header: key, key }));
+    rows.forEach((row) => worksheet.addRow(row));
+
     let url: string | undefined;
     try {
       const buffer = await workbook.xlsx.writeBuffer();
@@ -268,14 +353,9 @@ const Reports = () => {
     );
   }
 
-  if (reports.length === 0) {
-    return (
-      <Container maxWidth="lg">
-        <Typography variant="h4" gutterBottom>Reports</Typography>
-        <Typography color="textSecondary">No report types available</Typography>
-      </Container>
-    );
-  }
+  const downloadDisabled = isComplianceTab
+    ? loadingCompliance || complianceRows.length === 0
+    : loadingSubmissions || submissions.length === 0;
 
   return (
     <Container maxWidth="lg">
@@ -303,7 +383,7 @@ const Reports = () => {
             size="small"
             startIcon={<DownloadIcon />}
             onClick={handleDownload}
-            disabled={loadingSubmissions || submissions.length === 0}
+            disabled={downloadDisabled}
             sx={{ textTransform: 'none' }}
           >
             Download
@@ -316,11 +396,12 @@ const Reports = () => {
         <FormControl fullWidth sx={{ mb: 2 }}>
           <Select
             value={activeTab ?? ''}
-            onChange={(e) => setActiveTab(Number(e.target.value))}
+            onChange={(e) => setActiveTab(e.target.value === COMPLIANCE_TAB_ID ? COMPLIANCE_TAB_ID : Number(e.target.value))}
           >
             {reports.map((report) => (
               <MenuItem key={report.id} value={report.id}>{report.name}</MenuItem>
             ))}
+            <MenuItem value={COMPLIANCE_TAB_ID}>Submission Compliance</MenuItem>
           </Select>
         </FormControl>
       ) : (
@@ -334,24 +415,36 @@ const Reports = () => {
           {reports.map((report) => (
             <Tab key={report.id} label={report.name} value={report.id} />
           ))}
+          <Tab label="Submission Compliance" value={COMPLIANCE_TAB_ID} />
         </Tabs>
       )}
+
       {/* MC Attendance for the Week */}
-      {!mcaLoading && mcaSummary?.reportFound && (dateRange === '7') &&(
-        <Box sx={{marginY:2, backgroundColor: 'text.primary', padding: 2, borderRadius: 1, color: 'background.paper'}}>
+      {!mcaLoading && mcaSummary?.reportFound && (dateRange === '7') && (
+        <Box sx={{ marginY: 2, backgroundColor: 'text.primary', padding: 2, borderRadius: 1, color: 'background.paper' }}>
           <Typography variant="h5">
             This Week's Total Fellowship Attendance: {mcaSummary.total}
           </Typography>
-        </Box>  
+        </Box>
       )}
 
       {/* Table */}
-      <ReportsTable
-        columns={columns}
-        data={submissions}
-        loading={loadingSubmissions}
-        onRowClick={handleRowClick}
-      />
+      {isComplianceTab ? (
+        <ComplianceTable
+          rows={complianceRows}
+          loading={loadingCompliance}
+          showWeeksMissed={dateRange !== '7'}
+        />
+      ) : reports.length === 0 ? (
+        <Typography color="textSecondary">No report types available</Typography>
+      ) : (
+        <ReportsTable
+          columns={columns}
+          data={submissions}
+          loading={loadingSubmissions}
+          onRowClick={handleRowClick}
+        />
+      )}
 
       {/* Details Modal */}
       <SubmissionDetailsModal

--- a/src/modules/reports/ReportsTable.tsx
+++ b/src/modules/reports/ReportsTable.tsx
@@ -12,17 +12,13 @@ import {
   IconButton,
 } from '@mui/material';
 import { MoreVert } from '@mui/icons-material';
-
-interface Column {
-  name: string;
-  label: string;
-}
+import type {Column, SubmissionRow } from '../../utils/types';
 
 interface Props {
   columns: Column[];
-  data: Record<string, any>[];
+  data: SubmissionRow[];
   loading: boolean;
-  onRowClick: (row: Record<string, any>) => void;
+  onRowClick: (row: SubmissionRow) => void;
 }
 
 const ReportsTable = ({ columns, data, loading, onRowClick }: Props) => {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -221,6 +221,21 @@ export interface UserOption {
   fullName: string;
 }
 
+export interface Column {
+  name: string;
+  label: string;
+}
+
+// A single submission row as returned by the submissions endpoint. `data`
+// holds the dynamic, report-specific field values keyed by column name.
+export interface SubmissionRow {
+  id: number;
+  data: Record<string, unknown>;
+  submittedBy: string | { name: string };
+  submittedAt: string;
+  [key: string]: unknown;
+}
+
 export type UsersByLocationResponse = UserOption[] | { data: UserOption[] };
 
 export function extractUsersByLocation(


### PR DESCRIPTION
# Summary of changes
- Adds a new "Submission Compliance" tab to the Reports page, listing MC leaders who have not submitted their MC Attendance Report for the selected reporting period.
- Reuses the existing date range filter (Last 7 days / Last 30 days / All time) and reinterprets it in weekly terms for compliance: 7 days = current reporting week only, 30 days = last 4 completed weeks, all time = backend-capped lookback (~12 weeks).
- Adds a new `ComplianceTable.tsx` component (separate from `ReportsTable.tsx`, which is unchanged) showing MC Leader, MC Group, and Weeks Missed (with a tooltip listing the specific missed week dates). Only leaders with at least one missed week are shown.
- Wires the existing Download button to also export compliance data to xlsx when the Compliance tab is active.

# How should this be tested?
1. Navigate to Reports and confirm a new "Submission Compliance" tab appears after the existing dynamic report tabs (and in the mobile dropdown).
2. As a leader who manages one or more MC groups, select the Compliance tab:
   - With "Last 7 days" selected, confirm only MC groups that have not submitted the MC Attendance Report for the current week appear.
   - With "Last 30 days" selected, confirm groups that missed at least one of the last 4 weeks appear, with the correct "X / Y weeks missed" count.
   - Hover the "Weeks missed" value and confirm the tooltip lists the correct missed week start dates.
3. Confirm a leader who is fully compliant sees the "All MC leaders have submitted for the selected period" empty state, not a list.
4. Confirm a leader only sees compliance data for MC groups within their own management scope (not other zones/leaders' groups) — depends on the corresponding server-side change.
5. Click Download while on the Compliance tab and confirm the exported xlsx contains MC Leader, MC Group, Weeks Missed, and Missed Weeks columns (no "Status" column).
6. Switch back to a regular report tab and confirm existing submission browsing/export behavior is unchanged.

# Notes for reviewers
- `ReportsTable.tsx` was intentionally left untouched rather than generalized with a boolean flag to support both submission rows and compliance rows — the two data shapes are different enough that a dedicated `ComplianceTable.tsx` was cleaner and avoids a flag-driven component.
- Depends on the server PR's new `GET /reports/mc/compliance` endpoint being deployed; without it this tab will show an error toast on load.
- The "Status" chip column from an earlier draft was removed — since every row is now, by definition, a non-compliant leader, a separate status column was redundant with the weeks-missed count.

# Out of scope
- Filtering the Compliance tab by zone/campus (currently shows everything within the caller's manageable groups, unfiltered further).
- Any UI to trigger reminder notifications to non-compliant leaders directly from this tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Submission Compliance tab to Reports on desktop and mobile.
  * Displays compliance status, leader and group details, loading states, and empty states.
  * Optionally shows missed weeks with date details.
  * Added separate Excel export support for compliance data.
  * Compliance results support week-based date range filtering.
  * Report navigation and content adapt to the selected report type, including unavailable-data handling.
  * Improved report data consistency and row interactions across submission reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->