### PR TITLE
fix:Standardize bulk upload CSV field labels (frontend)

### DIFF
--- a/src/modules/contacts/BulkUpload.tsx
+++ b/src/modules/contacts/BulkUpload.tsx
@@ -65,7 +65,7 @@ const TEMPLATES: Record<UploadMode, string> = {
   contacts:
     'First Name,Last Name,Email,Phone,Date of Birth,Gender,District,Country',
   guests:
-    'First Name,Last Name,Phone,Email,Address,How Did You Hear About Us,How May We Pray For You,Service Date',
+    'First Name,Last Name,Phone,Email,Address,How Did You Hear About Us,How May We Pray For You, Church Location, Service Date',
   believers:
     'First Name,Last Name,Phone,Email,Address,Led to Christ By,Led to Christ On,Notes',
   redzone: 'First Name,Last Name,Phone,Email,Gender,Notes',
@@ -369,8 +369,9 @@ const BulkUpload = ({ onComplete, onCancel }: BulkUploadProps) => {
             <br />• <strong>Last Name</strong> (required)
             <br />• <strong>Email</strong> (required — used for login)
             <br />• <strong>Phone</strong>
-            <br />• <strong>Date of Birth</strong> - DD/MM/YYYY, e.g. 5/Jan/1990
+            <br />• <strong>Date of Birth</strong> (DD/MM/YYYY, e.g. 05/01/1990 Unsupported formats are silently dropped.)
             <br />• <strong>Gender</strong> (Male/Female)
+            <br />• <strong>District</strong>
             <br />• <strong>Country</strong> (required)
             <br />
           </Typography>

--- a/src/modules/contacts/BulkUpload.tsx
+++ b/src/modules/contacts/BulkUpload.tsx
@@ -63,7 +63,7 @@ type UploadResult = ContactsUploadResult | ServiceUploadResult;
 
 const TEMPLATES: Record<UploadMode, string> = {
   contacts:
-    'firstName,lastName,email,phone,dateOfBirth,gender,district,country',
+    'First Name,Last Name,Email,Phone,Date of Birth,Gender,District,Country',
   guests:
     'First Name,Last Name,Phone,Email,Address,How Did You Hear About Us,How May We Pray For You,Service Date',
   believers:
@@ -365,15 +365,13 @@ const BulkUpload = ({ onComplete, onCancel }: BulkUploadProps) => {
             Required CSV Columns:
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            • <strong>firstName</strong> - First name (required)
-            <br />• <strong>lastName</strong> - Last name (required)
-            <br />• <strong>email</strong> - Email address (required — used for
-            login)
-            <br />• <strong>phone</strong> - Phone number
-            <br />• <strong>dateOfBirth</strong> - Date of birth (YYYY-MM-DD
-            format)
-            <br />• <strong>gender</strong> - Gender (Male/Female)
-            <br />• <strong>country</strong> - Country (required)
+            • <strong>First Name</strong> (required)
+            <br />• <strong>Last Name</strong> (required)
+            <br />• <strong>Email</strong> (required — used for login)
+            <br />• <strong>Phone</strong>
+            <br />• <strong>Date of Birth</strong> - DD/MM/YYYY, e.g. 5/Jan/1990
+            <br />• <strong>Gender</strong> (Male/Female)
+            <br />• <strong>Country</strong> (required)
             <br />
           </Typography>
         </Box>
@@ -385,16 +383,16 @@ const BulkUpload = ({ onComplete, onCancel }: BulkUploadProps) => {
             Required columns:
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            • <strong>firstName</strong> - First name (required)
-            <br />• <strong>lastName</strong> - Last name (required)
-            <br />• <strong>phone</strong> - Phone number
+            • <strong>First Name</strong> (required)
+            <br />• <strong>Last Name</strong> (required)
+            <br />• <strong>Phone</strong>
             <br />
           </Typography>
           <Typography variant="subtitle2" gutterBottom sx={{ mt: 1 }}>
             Optional columns:
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            • <strong>email</strong> - Email address
+            • <strong>Email</strong>
             <br />• <strong>Address</strong>
             <br />• <strong>How Did You Hear About Us</strong>
             <br />• <strong>How May We Pray For You</strong>
@@ -413,16 +411,16 @@ const BulkUpload = ({ onComplete, onCancel }: BulkUploadProps) => {
             Required columns:
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            • <strong>firstName</strong> - First name (required)
-            <br />• <strong>lastName</strong> - Last name (required)
-            <br />• <strong>phone</strong> - Phone number
+            • <strong>First Name</strong> (required)
+            <br />• <strong>Last Name</strong> (required)
+            <br />• <strong>Phone</strong>
             <br />
           </Typography>
           <Typography variant="subtitle2" gutterBottom sx={{ mt: 1 }}>
             Optional columns:
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            • <strong>email</strong> - Email address
+            • <strong>Email</strong>
             <br />• <strong>Address</strong>
             <br />• <strong>Led to Christ By</strong>
             <br />• <strong>Led to Christ On</strong> — YYYY-MM-DD or


### PR DESCRIPTION
# Standardize bulk upload CSV field labels (frontend)

## Summary of Changes
- Changed the Contacts CSV template from camelCase headers (`firstName,lastName,...`) to human-readable ones (`First Name,Last Name,Email,Phone,Date of Birth,Gender,District,Country`), matching the format already used by Guests, Believers, and Red Zone templates.
- Updated the "Required/Optional columns" help text under all four upload modes to consistently use human-readable labels (`First Name` instead of `firstName`, etc.). Guests and Believers previously showed lowercase/camelCase column names in this text despite their actual CSV templates already using human-readable headers.
- Removed redundant label restatements in the Contacts help text (e.g. "**First Name** - First name (required)" → "**First Name** (required)") where the description just repeated the label with no added information. Left descriptions in place where they add real info (Email's login note, Date of Birth's format note).
- Corrected the Contacts "Date of Birth" format hint from `YYYY-MM-DD` to `DD/MM/YYYY` (e.g. `5/Jan/1990`) to match what the backend parser (`parseDateOfBirth`) actually accepts, and noted that unrecognized formats are silently dropped.

## How This Should Be Tested
- Open Bulk Upload, switch between all four modes (Contacts / Guests / Believers / Red Zone), and confirm the "Download Sample CSV" button produces a file with human-readable headers in every mode.
- Visually check the "Required/Optional columns" text under each mode for consistent `First Name` / `Last Name` / `Email` / etc. casing and no redundant descriptions.
- Upload a Contacts CSV with a Date of Birth in `DD/MM/YYYY` format and confirm it saves correctly; try `YYYY-MM-DD` and confirm current (unchanged) behavior — value is dropped, no error shown — matches the corrected copy.
- No changes to upload/submit logic, so existing upload flows (success/error states, error list rendering) should behave exactly as before — a quick smoke test of a normal upload per mode is enough.

## Note for Reviewers
- This PR is copy/labels only on the frontend — no changes to request payloads, validation, or component logic. Pairs with the companion server PR that adds header-normalization for the Contacts endpoint so the new human-readable Contacts template actually parses correctly server-side.
- Guests/Believers/Red Zone needed no backend changes — their service (`ServiceRecordingService`) already lowercases and matches headers by human-readable name, so only the stale docs text there needed fixing.

## Out of Scope
- The silent-failure behavior of `parseDateOfBirth` (returns `null` with no user-facing warning on unparseable dates, unlike Guests/Believers' `parseDate` which surfaces a per-row warning) — flagged as a possible follow-up, not fixed here.
- `groupName` / `groupParentId` in the Group Leaders upload path remain camelCase-only with no human-readable alternative — out of scope unless that endpoint is prioritized separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contact CSV templates and column instructions with clearer, human-readable headers.
  * Added the `District` field and guidance for entering contact dates in `DD/MM/YYYY` format.
  * Updated guest templates to include `Church Location`.
  * Clarified required and optional column labels for guest and believer imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->