### PR TITLE
feat: offline response handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import type { ReactElement } from 'react';
 import {
   BrowserRouter as Router,
@@ -26,6 +26,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 // Import actual components
 import Login from './modules/login/Login';
+import OfflinePage from './modules/login/OfflinePage';
 import ForgotPassword from './modules/login/ForgotPassword';
 import SignUp from './modules/login/SignUp';
 import ResetPassword from './modules/login/ResetPassword';
@@ -92,11 +93,20 @@ const LoaderDialog = ({ open }: { open: boolean }) =>
 
 function App() {
   const dispatch = useDispatch();
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+
   const { user, isLoadingUser, globalLoader } = useSelector(
     (state: RootState) => state.core,
   );
 
   useEffect(() => {
+    // Track browser connectivity
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
     // Try to restore user from localStorage on app start
     const storedUser = localStorage.getItem(AUTH_USER_KEY);
     const token = localStorage.getItem(AUTH_TOKEN_KEY);
@@ -112,6 +122,11 @@ function App() {
     } else {
       dispatch(logout());
     }
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
   }, [dispatch]);
 
   if (isLoadingUser) {
@@ -143,6 +158,9 @@ function App() {
       <LoaderDialog open={globalLoader} />
       <PwaInstallPrompt />
       {user ? (
+        <>
+           <OfflinePage open={!isOnline} />
+
         <LayoutV2>
           <Routes>
             <Route path={localRoutes.dashboard} element={<Dashboard />} />
@@ -305,6 +323,7 @@ function App() {
             <Route path="*" element={<Dashboard />} />
           </Routes>
         </LayoutV2>
+      </>
       ) : (
         <Routes>
           <Route

--- a/src/modules/login/Login.test.tsx
+++ b/src/modules/login/Login.test.tsx
@@ -181,6 +181,34 @@ describe('form submission', () => {
       expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe(fakeToken);
     });
   });
+
+  it('shows no internet error when offline', async () => {
+    const user = userEvent.setup();
+
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      value: false,
+    });
+
+    renderLogin();
+
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(
+      screen.getByRole('dialog', { name: /no internet connection/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: /try again/i }),
+    ).toBeInTheDocument();
+
+    expect(mockPost).not.toHaveBeenCalled();
+
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      value: true,
+    });
+  });
 });
 
 // ─── navigation links ─────────────────────────────────────────────────────────

--- a/src/modules/login/Login.test.tsx
+++ b/src/modules/login/Login.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
@@ -13,6 +13,11 @@ vi.mock('../../utils/ajax', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../utils/ajax')>();
   return { ...actual, post: vi.fn() };
 });
+
+const originalOnlineDescriptor = Object.getOwnPropertyDescriptor(
+  Navigator.prototype,
+  'onLine',
+);
 
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -38,6 +43,16 @@ beforeEach(() => {
   mockPost.mockClear();
   mockNavigate.mockClear();
   localStorage.clear();
+});
+
+afterEach(() => {
+  if (originalOnlineDescriptor) {
+    Object.defineProperty(
+      Navigator.prototype,
+      'onLine',
+      originalOnlineDescriptor,
+    );
+  }
 });
 
 // ─── rendering ───────────────────────────────────────────────────────────────
@@ -185,9 +200,9 @@ describe('form submission', () => {
   it('shows no internet error when offline', async () => {
     const user = userEvent.setup();
 
-    Object.defineProperty(navigator, 'onLine', {
+    Object.defineProperty(Navigator.prototype, 'onLine', {
       configurable: true,
-      value: false,
+      get: () => false,
     });
 
     renderLogin();
@@ -203,11 +218,6 @@ describe('form submission', () => {
     ).toBeInTheDocument();
 
     expect(mockPost).not.toHaveBeenCalled();
-
-    Object.defineProperty(navigator, 'onLine', {
-      configurable: true,
-      value: true,
-    });
   });
 });
 

--- a/src/modules/login/Login.tsx
+++ b/src/modules/login/Login.tsx
@@ -18,6 +18,7 @@ import { post } from '../../utils/ajax';
 import { remoteRoutes, localRoutes } from '../../data/constants';
 import loginBackground from '../../assets/images/login-background.jpg';
 import HelpFab, { NARROW_SCREEN_QUERY } from './HelpFab';
+import OfflinePage from './OfflinePage';
 
 const Login = () => {
   const dispatch = useDispatch();
@@ -30,6 +31,7 @@ const Login = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [showOfflinePage, setShowOfflinePage] = useState(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({
@@ -40,6 +42,12 @@ const Login = () => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (!navigator.onLine) {
+      setShowOfflinePage(true);
+      return;
+    }
+
     setLoading(true);
     setError('');
 
@@ -67,6 +75,7 @@ const Login = () => {
       }}
     >
       <HelpFab />
+      <OfflinePage open={showOfflinePage} />
 
       {/* Mobile image masthead */}
       <Box

--- a/src/modules/login/OfflinePage.test.tsx
+++ b/src/modules/login/OfflinePage.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import OfflinePage from './OfflinePage';
+
+describe('OfflinePage', () => {
+    it('renders the offline message', () => {
+        render(<OfflinePage open={true} />);
+
+        expect(screen.getByText('No Internet Connection')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                'Please check your internet connection and try again.',
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('reloads the page when Try Again is clicked', () => {
+        const reload = vi.fn();
+
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { reload },
+        });
+
+        render(<OfflinePage open={true} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
+
+        expect(reload).toHaveBeenCalled();
+    });
+});

--- a/src/modules/login/OfflinePage.test.tsx
+++ b/src/modules/login/OfflinePage.test.tsx
@@ -1,31 +1,35 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import OfflinePage from './OfflinePage';
 
+const { mockReloadPage } = vi.hoisted(() => ({
+  mockReloadPage: vi.fn(),
+}));
+
+vi.mock('../../utils/browser', () => ({
+  reloadPage: mockReloadPage,
+}));
+
+beforeEach(() => {
+  mockReloadPage.mockClear();
+});
+
 describe('OfflinePage', () => {
-    it('renders the offline message', () => {
-        render(<OfflinePage open={true} />);
+  it('renders the offline message', () => {
+    render(<OfflinePage open={true} />);
 
-        expect(screen.getByText('No Internet Connection')).toBeInTheDocument();
-        expect(
-            screen.getByText(
-                'Please check your internet connection and try again.',
-            ),
-        ).toBeInTheDocument();
-    });
+    expect(
+      screen.getByRole('dialog', { name: /no internet connection/i }),
+    ).toBeInTheDocument();
+  });
 
-    it('reloads the page when Try Again is clicked', () => {
-        const reload = vi.fn();
+  it('reloads the page when Try Again is clicked', () => {
+    render(<OfflinePage open={true} />);
 
-        Object.defineProperty(window, 'location', {
-            configurable: true,
-            value: { reload },
-        });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Try Again' }),
+    );
 
-        render(<OfflinePage open={true} />);
-
-        fireEvent.click(screen.getByRole('button', { name: 'Try Again' }));
-
-        expect(reload).toHaveBeenCalled();
-    });
+    expect(mockReloadPage).toHaveBeenCalled();
+  });
 });

--- a/src/modules/login/OfflinePage.tsx
+++ b/src/modules/login/OfflinePage.tsx
@@ -1,0 +1,103 @@
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    Typography,
+} from '@mui/material';
+import WifiOffRoundedIcon from '@mui/icons-material/WifiOffRounded';
+
+interface OfflinePageProps {
+    open: boolean;
+}
+
+const OfflinePage = ({ open }: OfflinePageProps) => {
+    const handleRetry = () => {
+        window.location.reload();
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onClose={() => { }}
+            aria-labelledby="offline-dialog-title"
+            disableEscapeKeyDown
+            slotProps={{
+                backdrop: {
+                    sx: {
+                        backdropFilter: 'blur(4px)',
+                        backgroundColor: 'rgba(0, 0, 0, 0.45)',
+                    },
+                },
+            }}
+            PaperProps={{
+                sx: {
+                    width: 'fit-content',
+                    maxWidth: 420,
+                    borderRadius: 3,
+                    mx: 2,
+                },
+            }}
+        >
+            <div
+                style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    paddingTop: '8px',
+                }}
+            >
+                <WifiOffRoundedIcon
+                    sx={{
+                        fontSize: 42,
+                        color: 'text.secondary',
+                    }}
+                />
+            </div>
+
+            <DialogTitle
+                id="offline-dialog-title"
+                sx={{
+                    textAlign: 'center',
+                    pb: 1,
+                    fontWeight: 700,
+                }}
+            >
+                No Internet Connection
+            </DialogTitle>
+
+            <DialogContent
+                sx={{
+                    textAlign: 'center',
+                    px: { xs: 3, sm: 4 },
+                    pb: 1,
+                }}
+            >
+                <Typography color="text.secondary">
+                    Please check your internet connection and try again.
+                </Typography>
+            </DialogContent>
+
+            <DialogActions
+                sx={{
+                    justifyContent: 'center',
+                    px: 3,
+                    pb: 3,
+                    pt: 1,
+                }}
+            >
+                <Button
+                    variant="contained"
+                    onClick={handleRetry}
+                    sx={{
+                        minWidth: 120,
+                    }}
+                >
+                    Try Again
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default OfflinePage;

--- a/src/modules/login/OfflinePage.tsx
+++ b/src/modules/login/OfflinePage.tsx
@@ -7,6 +7,7 @@ import {
     Typography,
 } from '@mui/material';
 import WifiOffRoundedIcon from '@mui/icons-material/WifiOffRounded';
+import { reloadPage } from '../../utils/browser';
 
 interface OfflinePageProps {
     open: boolean;
@@ -14,7 +15,7 @@ interface OfflinePageProps {
 
 const OfflinePage = ({ open }: OfflinePageProps) => {
     const handleRetry = () => {
-        window.location.reload();
+        reloadPage();
     };
 
     return (

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -1,0 +1,3 @@
+export const reloadPage = () => {
+  window.location.reload();
+};


### PR DESCRIPTION
# Ticket No
- Ticket number here

## Summary of changes
- Created a new pop-up offline modal to show the user there's no internet connection when they no longer have an active internet connection.

## Testing
- Attempt to access the system without an internet connection.
- Attempt to sign in and the no internet pop up will show

## Notes for reviewers
- No added notes

## Out of scope
-  No out of scope, maybe different UI/UX suggestions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an offline notification for authenticated users when internet connectivity is unavailable.
  * Login now detects offline submissions and displays a connection warning instead of attempting authentication.
  * Added a “Try Again” action that reloads the page to retry the connection.

* **Tests**
  * Added coverage for offline login behavior, notification display, and retry functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->