### PR TITLE
Detect offline state on Login load, not just on submit

### DIFF
--- a/src/modules/login/Login.test.tsx
+++ b/src/modules/login/Login.test.tsx
@@ -197,17 +197,13 @@ describe('form submission', () => {
     });
   });
 
-  it('shows no internet error when offline', async () => {
-    const user = userEvent.setup();
-
+  it('shows no internet error when offline', () => {
     Object.defineProperty(Navigator.prototype, 'onLine', {
       configurable: true,
       get: () => false,
     });
 
     renderLogin();
-
-    await user.click(screen.getByRole('button', { name: /sign in/i }));
 
     expect(
       screen.getByRole('dialog', { name: /no internet connection/i }),
@@ -218,6 +214,27 @@ describe('form submission', () => {
     ).toBeInTheDocument();
 
     expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('dismisses the offline dialog when connectivity is restored', async () => {
+    Object.defineProperty(Navigator.prototype, 'onLine', {
+      configurable: true,
+      get: () => false,
+    });
+
+    renderLogin();
+
+    expect(
+      screen.getByRole('dialog', { name: /no internet connection/i }),
+    ).toBeInTheDocument();
+
+    window.dispatchEvent(new Event('online'));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', { name: /no internet connection/i }),
+      ).not.toBeInTheDocument(),
+    );
   });
 });
 

--- a/src/modules/login/Login.tsx
+++ b/src/modules/login/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   TextField,
   Button,
@@ -31,7 +31,20 @@ const Login = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [showOfflinePage, setShowOfflinePage] = useState(false);
+  const [showOfflinePage, setShowOfflinePage] = useState(!navigator.onLine);
+
+  useEffect(() => {
+    const handleOnline = () => setShowOfflinePage(false);
+    const handleOffline = () => setShowOfflinePage(true);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({


### PR DESCRIPTION
## Summary
- Initialize the Login page's offline dialog from `navigator.onLine` on mount, so it shows immediately if the app loads while offline instead of only after a submit attempt.
- Listen for `online`/`offline` window events to toggle the dialog as connectivity changes.
- Updated `shows no internet error when offline` test to reflect that the dialog now appears on load rather than requiring a submit click.

## Test plan
- [x] `npx vitest run src/modules/login/Login.test.tsx` — 17 passed
- [x] `npx eslint src/modules/login/Login.tsx src/modules/login/Login.test.tsx` — only pre-existing errors (verified identical on `develop`)
- [x] `npx tsc -b --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The login screen now immediately reflects the browser’s current internet connection status.
  * The offline message appears when connectivity is lost and dismisses automatically when the connection is restored.
  * Connectivity monitoring is handled reliably while the login screen is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->