### PR TITLE
feat:add reports edit and edit deadline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -191,6 +191,12 @@ function App() {
               ])}
             />
             <Route
+              path="/reports/:reportId/submissions/:submissionId/edit"
+              element={renderProtectedElement(<ReportSubmissionForm />, [
+                appPermissions.roleReportView,
+              ])}
+            />
+            <Route
               path={localRoutes.groups}
               element={renderProtectedElement(<Groups />, [
                 appPermissions.roleGroupView,

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -175,6 +175,7 @@ const ReportSubmissionForm = () => {
   const { user } = useSelector((state: RootState) => state.core);
 
   const isEditMode = Boolean(submissionId);
+  const [submissionLoading, setSubmissionLoading] = useState(isEditMode);
   const [reportName, setReportName] = useState('');
   const [reportFields, setReportFields] = useState<IReportField[]>([]);
   const [formData, setFormData] = useState<Record<string, $TsFixMe>>({});
@@ -298,10 +299,12 @@ const ReportSubmissionForm = () => {
         if (response?.groupId) {
           setSelectedGroupId(response.groupId);
         }
+        setSubmissionLoading(false);
       },
       (error: $TsFixMe) => {
         console.error('Failed to fetch submission for editing:', error);
         toast.error('Failed to load submission for editing');
+        navigate(localRoutes.dashboard);
       },
     );
     // Intentionally excludes reportFields from deps beyond the length
@@ -649,6 +652,7 @@ const ReportSubmissionForm = () => {
   };
 
   const handleSubmit = () => {
+    if (isEditMode && submissionLoading) return;
     const errors: Record<string, string> = {};
     let hiddenFieldMissing = false;
     reportFields.forEach((field) => {
@@ -1220,7 +1224,7 @@ const ReportSubmissionForm = () => {
     }
   };
 
-  if (loading) {
+  if (loading || submissionLoading) {
     return (
       <Container maxWidth="md">
         <Box

--- a/src/modules/reports/ReportSubmissionForm.tsx
+++ b/src/modules/reports/ReportSubmissionForm.tsx
@@ -170,10 +170,11 @@ const getManagedGroupIdSet = (
 };
 
 const ReportSubmissionForm = () => {
-  const { reportId } = useParams<{ reportId: string }>();
+  const { reportId, submissionId } = useParams<{ reportId: string; submissionId?: string }>();
   const navigate = useNavigate();
   const { user } = useSelector((state: RootState) => state.core);
 
+  const isEditMode = Boolean(submissionId);
   const [reportName, setReportName] = useState('');
   const [reportFields, setReportFields] = useState<IReportField[]>([]);
   const [formData, setFormData] = useState<Record<string, $TsFixMe>>({});
@@ -278,6 +279,36 @@ const ReportSubmissionForm = () => {
       },
     );
   }, [reportId]);
+  // In edit mode, prefill formData once the report's fields are known --
+  // fields must load first so isDynamicMemberField/etc. checks below
+  // (and the dynamic-option fetch effect) have something to match against.
+  useEffect(() => {
+    if (!isEditMode || reportFields.length === 0) return;
+
+    get(
+      `${remoteRoutes.reports}/${reportId}/submissions/${submissionId}?raw=true`,
+      (response: $TsFixMe) => {
+        if (response?.data) {
+          // Saved submission values are authoritative during edit
+          // hydration -- merge them on top of whatever's already in
+          // formData (e.g. a default an auto-select effect wrote before
+          // this request resolved), not the other way around.
+          setFormData((prev) => ({ ...prev, ...response.data }));
+        }
+        if (response?.groupId) {
+          setSelectedGroupId(response.groupId);
+        }
+      },
+      (error: $TsFixMe) => {
+        console.error('Failed to fetch submission for editing:', error);
+        toast.error('Failed to load submission for editing');
+      },
+    );
+    // Intentionally excludes reportFields from deps beyond the length
+    // gate -- this should run once fields are available, not re-run on
+    // every fields re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEditMode, reportId, submissionId, reportFields.length]);
 
   const isDynamicGroupField = (field: IReportField): boolean => {
     if (!field.options || !Array.isArray(field.options)) return false;
@@ -396,8 +427,10 @@ const ReportSubmissionForm = () => {
         setDynamicOptions((prev) => ({ ...prev, [field.name]: groups }));
         setDynamicLoading((prev) => ({ ...prev, [field.name]: false }));
 
-        // Auto-select if only one option
-        if (groups.length === 1) {
+        // Auto-select if only one option -- skip in edit mode, where the
+        // saved submission value (loaded by the hydration effect) is
+        // authoritative and must not be clobbered by this default.
+        if (groups.length === 1 && !isEditMode) {
           handleDynamicGroupChange(field, groups[0]);
         }
       },
@@ -434,7 +467,10 @@ const ReportSubmissionForm = () => {
         setSmallGroups(groups);
         setSmallGroupsLoading(false);
 
-        if (groups.length === 1) {
+        // Skip auto-select in edit mode -- same reasoning as the dynamic
+        // group/schedule fetches above: the saved value from hydration
+        // must win, not this convenience default.
+        if (groups.length === 1 && !isEditMode) {
           setFormData((prev) => {
             if (prev.smallGroupName || prev.smallGroupId) {
               return prev;
@@ -489,7 +525,11 @@ const ReportSubmissionForm = () => {
       (response: ScheduleData) => {
         setFellowshipSchedules((prev) => ({ ...prev, [field.name]: response }));
         setDynamicLoading((prev) => ({ ...prev, [field.name]: false }));
-        if (response.exists && response.day !== undefined) {
+        // In edit mode, the saved submission's day (from hydration) is
+        // authoritative -- the leader's *current* recurring schedule may
+        // have changed since this submission was made, and must not
+        // silently overwrite what was actually reported.
+        if (!isEditMode && response.exists && response.day !== undefined) {
           handleChange(field.name, response.day);
         }
       },
@@ -656,22 +696,34 @@ const ReportSubmissionForm = () => {
     const submissionData: Record<string, $TsFixMe> = { data: formData };
     if (selectedGroupId) submissionData.selectedGroupId = selectedGroupId;
 
-    // Use correct endpoint: POST /api/reports/:reportId/submissions
-    post(
-      `${remoteRoutes.reports}/${reportId}/submissions`,
-      submissionData,
-      () => {
-        toast.success('Report submitted successfully');
-        navigate(localRoutes.dashboard);
-      },
-      (error: $TsFixMe) => {
-        console.error('Submission failed:', error);
-        const message =
-          error?.response?.data?.message || 'Failed to submit report';
-        toast.error(message);
-        setSubmitting(false);
-      },
-    );
+    const onSubmitSuccess = () => {
+      toast.success(isEditMode ? 'Report updated successfully' : 'Report submitted successfully');
+      navigate(localRoutes.dashboard);
+    };
+    const onSubmitError = (error: $TsFixMe) => {
+      console.error('Submission failed:', error);
+      const message =
+        error?.response?.data?.message ||
+        (isEditMode ? 'Failed to update report' : 'Failed to submit report');
+      toast.error(message);
+      setSubmitting(false);
+    };
+
+    if (isEditMode) {
+      put(
+        `${remoteRoutes.reports}/${reportId}/submissions/${submissionId}`,
+        submissionData,
+        onSubmitSuccess,
+        onSubmitError,
+      );
+    } else {
+      post(
+        `${remoteRoutes.reports}/${reportId}/submissions`,
+        submissionData,
+        onSubmitSuccess,
+        onSubmitError,
+      );
+    }
   };
 
   const renderField = (field: IReportField) => {

--- a/src/modules/reports/Reports.tsx
+++ b/src/modules/reports/Reports.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Container,
   Typography,
@@ -48,6 +49,7 @@ interface SubmissionDetails {
   labels: { name: string; label: string }[];
   submittedAt: string;
   submittedBy: string;
+  canEdit: boolean;
 }
 
 interface ComplianceResponse {
@@ -83,6 +85,7 @@ const getErrorMessage = (error: unknown): string =>
 const Reports = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const navigate = useNavigate();
 
   const [reports, setReports] = useState<ReportType[]>([]);
   const [activeTab, setActiveTab] = useState<ActiveTab>(null);
@@ -267,6 +270,17 @@ const Reports = () => {
         setDetailsLoading(false);
       },
     );
+  };
+  
+  const handleEditClick = (row: SubmissionRow) => {
+    if (typeof activeTab !== 'number' || !row.id) return;
+    navigate(`/reports/${activeTab}/submissions/${row.id}/edit`);
+  };
+
+  const handleEditFromModal = () => {
+    if (typeof activeTab !== 'number' || !submissionDetails?.id) return;
+    setModalOpen(false);
+    navigate(`/reports/${activeTab}/submissions/${submissionDetails.id}/edit`);
   };
 
   const handleTabChange = (_: React.SyntheticEvent, newValue: ActiveTab) => {
@@ -453,6 +467,7 @@ const Reports = () => {
           data={submissions}
           loading={loadingSubmissions}
           onRowClick={handleRowClick}
+          onEditClick={handleEditClick}
         />
       )}
 
@@ -463,6 +478,7 @@ const Reports = () => {
         details={submissionDetails}
         loading={detailsLoading}
         reportName={activeReportName}
+        onEdit={handleEditFromModal}
       />
     </Container>
   );

--- a/src/modules/reports/ReportsTable.tsx
+++ b/src/modules/reports/ReportsTable.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   Table,
   TableBody,
@@ -10,18 +11,48 @@ import {
   CircularProgress,
   Box,
   IconButton,
+  Menu,
+  MenuItem,
 } from '@mui/material';
-import { MoreVert } from '@mui/icons-material';
-import type {Column, SubmissionRow } from '../../utils/types';
+import { MoreVert as MoreVertIcon } from '@mui/icons-material';
+import type { Column, SubmissionRow } from '../../utils/types';
 
 interface Props {
   columns: Column[];
   data: SubmissionRow[];
   loading: boolean;
   onRowClick: (row: SubmissionRow) => void;
+  onEditClick: (row: SubmissionRow) => void;
 }
 
-const ReportsTable = ({ columns, data, loading, onRowClick }: Props) => {
+const ReportsTable = ({ columns, data, loading, onRowClick, onEditClick }: Props) => {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [selectedRow, setSelectedRow] = useState<SubmissionRow | null>(null);
+
+  const handleMenuOpen = (
+    event: React.MouseEvent<HTMLElement>,
+    row: SubmissionRow,
+  ) => {
+    event.stopPropagation();
+    setAnchorEl(event.currentTarget);
+    setSelectedRow(row);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+    setSelectedRow(null);
+  };
+
+  const handleViewDetails = () => {
+    if (selectedRow) onRowClick(selectedRow);
+    handleMenuClose();
+  };
+
+  const handleEdit = () => {
+    if (selectedRow) onEditClick(selectedRow);
+    handleMenuClose();
+  };
+
   const formatCell = (value: any): string => {
     if (value === null || value === undefined) return '-';
     // Try to detect ISO date strings
@@ -74,7 +105,7 @@ const ReportsTable = ({ columns, data, loading, onRowClick }: Props) => {
               Submitted At
             </TableCell>
             <TableCell align="right" sx={{ fontWeight: 'bold' }}>
-              Action
+              Actions
             </TableCell>
           </TableRow>
         </TableHead>
@@ -102,18 +133,27 @@ const ReportsTable = ({ columns, data, loading, onRowClick }: Props) => {
               <TableCell align="right">
                 <IconButton
                   size="small"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRowClick(row);
-                  }}
+                  onClick={(e) => handleMenuOpen(e, row)}
                 >
-                  <MoreVert fontSize="small" />
+                  <MoreVertIcon fontSize="small" />
                 </IconButton>
               </TableCell>
             </TableRow>
           ))}
         </TableBody>
       </Table>
+
+      {/* Actions Menu */}
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleMenuClose}
+      >
+        <MenuItem onClick={handleViewDetails}>View Details</MenuItem>
+        {selectedRow?.canEdit && (
+          <MenuItem onClick={handleEdit}>Edit</MenuItem>
+        )}
+      </Menu>
     </TableContainer>
   );
 };

--- a/src/modules/reports/SubmissionDetailsModal.tsx
+++ b/src/modules/reports/SubmissionDetailsModal.tsx
@@ -23,6 +23,7 @@ interface SubmissionDetails {
   labels: SubmissionLabel[];
   submittedAt: string;
   submittedBy: string;
+  canEdit?: boolean;
 }
 
 interface Props {
@@ -31,6 +32,7 @@ interface Props {
   details: SubmissionDetails | null;
   loading: boolean;
   reportName: string;
+  onEdit?: () => void;
 }
 
 const SubmissionDetailsModal = ({
@@ -39,6 +41,7 @@ const SubmissionDetailsModal = ({
   details,
   loading,
   reportName,
+  onEdit,
 }: Props) => {
   const theme = useTheme();
   const isPhone = useMediaQuery(theme.breakpoints.down('sm'));
@@ -106,10 +109,15 @@ const SubmissionDetailsModal = ({
           <Typography color="textSecondary">No details available</Typography>
         )}
       </DialogContent>
-      <DialogActions>
+      <DialogActions>        
         <Button onClick={onClose} fullWidth={isPhone}>
           Close
         </Button>
+        {details?.canEdit && onEdit && (
+          <Button onClick={onEdit} variant="outlined">
+            Edit
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -233,6 +233,7 @@ export interface SubmissionRow {
   data: Record<string, unknown>;
   submittedBy: string | { name: string };
   submittedAt: string;
+  canEdit: boolean;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
# Ticket No
- TBD

# Summary of changes
- Added an Edit action to report submissions, gated by the `canEdit` flag returned by the backend.
- Reworked the Reports table's row actions into a single menu (View Details / Edit) instead of two separate icon buttons.
- Added an Edit button to the submission details modal, shown only when the submission is still editable.
- `ReportSubmissionForm` now supports edit mode: fetches the existing submission (`?raw=true`) and prefills the form, submitting via `PUT` instead of `POST`.
- Added a route for the edit form (`/reports/:reportId/submissions/:submissionId/edit`).
- Fixed a hydration race where dynamic field defaults (group auto-select, schedule auto-select, MC auto-select) could overwrite the saved submission's values while editing.

# How should this be tested? [Screenshots, Video or Type instructions]
1. As a leader with a recent MC Attendance submission, go to Reports and open a submission made this week.
2. Confirm the row's action menu shows "View Details" and, only if within the edit window, "Edit".
3. Click Edit — confirm the form loads with the previously submitted values already filled in, including the member checkboxes matching who was reported present.
4. Change a value and save — confirm it updates via `PUT` and returns you to the dashboard with a success toast.
5. Open the same submission's details modal — confirm the Edit button appears there too (within the edit window) and takes you to the same form.
6. Find or simulate a submission outside the edit window (past Sunday 6pm of its reporting cycle) — confirm no Edit option appears anywhere for it.

# Notes for reviewers
- Edit-mode field defaulting is intentionally suppressed (group/schedule/MC auto-select) so the saved submission value always wins over a freshly-computed default — see `ReportSubmissionForm`.
- The menu pattern mirrors the existing `Contacts.tsx` actions menu for consistency.

# Out of scope
- Editing submissions for reports other than the ones already wired into this form (no new field types added).
- Any change to the create-submission flow beyond what's needed to share code with edit mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added editing for report submissions through a dedicated edit workflow.
  - Existing submissions now load their saved details into the form for updating.
  - Added **Edit** actions to report tables and submission detail dialogs when permitted.
  - Added row-level actions menus with **View Details** and conditional **Edit** options.
  - Protected editing access based on user permissions.
  - Added loading feedback while saved submission details are retrieved.
  - Updated submission actions and messages to distinguish between creating and editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->