### PR TITLE
infra: open/close Contabo firewall SSH rule around deployments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,64 @@ jobs:
           name: npm-logs
           path: ~/.npm/_logs
 
+      - name: Open firewall for GitHub runner
+        id: firewall-open
+        env:
+          SERVER_CLIENT_ID: ${{ secrets.SERVER_CLIENT_ID }}
+          SERVER_CLIENT_SECRET: ${{ secrets.SERVER_CLIENT_SECRET }}
+          SERVER_API_USER: ${{ secrets.SERVER_API_USER }}
+          SERVER_API_PASSWORD: ${{ secrets.SERVER_API_PASSWORD }}
+          FIREWALL_ID: ${{ secrets.FIREWALL_ID }}
+        run: |
+          set -e
+
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          echo "runner_ip=${RUNNER_IP}" >> "$GITHUB_OUTPUT"
+
+          TOKEN=$(curl -s \
+            -d "client_id=${SERVER_CLIENT_ID}" \
+            -d "client_secret=${SERVER_CLIENT_SECRET}" \
+            --data-urlencode "username=${SERVER_API_USER}" \
+            --data-urlencode "password=${SERVER_API_PASSWORD}" \
+            -d "grant_type=password" \
+            'https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token' \
+            | jq -r '.access_token')
+
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "Failed to obtain Contabo access token"
+            exit 1
+          fi
+
+          FIREWALL=$(curl -s \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
+            "https://api.contabo.com/v1/firewalls/${FIREWALL_ID}")
+
+          CURRENT_INBOUND=$(echo "${FIREWALL}" | jq '.data[0].rules.inbound // []')
+
+          UPDATED_INBOUND=$(echo "${CURRENT_INBOUND}" | jq \
+            --arg ip "${RUNNER_IP}/32" \
+            'map(if .displayName == "GithubActionsCICD"
+              then . + {"srcCidr": {"ipv4": [$ip], "ipv6": []}, "status": "active"}
+              else .
+              end)')
+
+          PUT_BODY=$(jq -n --argjson inbound "$UPDATED_INBOUND" '{"rules": {"inbound": $inbound}}')
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
+            -H "Content-Type: application/json" \
+            -d "${PUT_BODY}" \
+            "https://api.contabo.com/v1/firewalls/${FIREWALL_ID}")
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Failed to update firewall (HTTP ${HTTP_CODE})"
+            exit 1
+          fi
+
+          echo "Firewall rule activated for ${RUNNER_IP}"
+
       - name: Configure SSH
         env:
           SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
@@ -61,3 +119,55 @@ jobs:
 
       - name: Deploy
         run: rsync -rtvO --delete ./dist/ projectzoe-prod:/opt/projectzoe/production/client/dist/
+
+      - name: Close firewall
+        if: always() && steps.firewall-open.conclusion == 'success'
+        env:
+          SERVER_CLIENT_ID: ${{ secrets.SERVER_CLIENT_ID }}
+          SERVER_CLIENT_SECRET: ${{ secrets.SERVER_CLIENT_SECRET }}
+          SERVER_API_USER: ${{ secrets.SERVER_API_USER }}
+          SERVER_API_PASSWORD: ${{ secrets.SERVER_API_PASSWORD }}
+          FIREWALL_ID: ${{ secrets.FIREWALL_ID }}
+        run: |
+          TOKEN=$(curl -s \
+            -d "client_id=${SERVER_CLIENT_ID}" \
+            -d "client_secret=${SERVER_CLIENT_SECRET}" \
+            --data-urlencode "username=${SERVER_API_USER}" \
+            --data-urlencode "password=${SERVER_API_PASSWORD}" \
+            -d "grant_type=password" \
+            'https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token' \
+            | jq -r '.access_token')
+
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "Failed to obtain Contabo access token for cleanup"
+            exit 1
+          fi
+
+          FIREWALL=$(curl -s \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
+            "https://api.contabo.com/v1/firewalls/${FIREWALL_ID}")
+
+          CURRENT_INBOUND=$(echo "${FIREWALL}" | jq '.data[0].rules.inbound // []')
+
+          UPDATED_INBOUND=$(echo "${CURRENT_INBOUND}" | jq \
+            'map(if .displayName == "GithubActionsCICD"
+              then . + {"status": "inactive"}
+              else .
+              end)')
+
+          PUT_BODY=$(jq -n --argjson inbound "$UPDATED_INBOUND" '{"rules": {"inbound": $inbound}}')
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
+            -H "Content-Type: application/json" \
+            -d "${PUT_BODY}" \
+            "https://api.contabo.com/v1/firewalls/${FIREWALL_ID}")
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Failed to close firewall (HTTP ${HTTP_CODE})"
+            exit 1
+          fi
+
+          echo "Firewall rule deactivated for ${{ steps.firewall-open.outputs.runner_ip }}"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -42,6 +42,64 @@ jobs:
           name: npm-logs
           path: ~/.npm/_logs
 
+      - name: Open firewall for GitHub runner
+        id: firewall-open
+        env:
+          SERVER_CLIENT_ID: ${{ secrets.SERVER_CLIENT_ID }}
+          SERVER_CLIENT_SECRET: ${{ secrets.SERVER_CLIENT_SECRET }}
+          SERVER_API_USER: ${{ secrets.SERVER_API_USER }}
+          SERVER_API_PASSWORD: ${{ secrets.SERVER_API_PASSWORD }}
+          FIREWALL_ID: ${{ secrets.FIREWALL_ID }}
+        run: |
+          set -e
+
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          echo "runner_ip=${RUNNER_IP}" >> "$GITHUB_OUTPUT"
+
+          TOKEN=$(curl -s \
+            -d "client_id=${SERVER_CLIENT_ID}" \
+            -d "client_secret=${SERVER_CLIENT_SECRET}" \
+            --data-urlencode "username=${SERVER_API_USER}" \
+            --data-urlencode "password=${SERVER_API_PASSWORD}" \
+            -d "grant_type=password" \
+            'https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token' \
+            | jq -r '.access_token')
+
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "Failed to obtain Contabo access token"
+            exit 1
+          fi
+
+          FIREWALL=$(curl -s \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
+            "https://api.contabo.com/v1/firewalls/${FIREWALL_ID}")
+
+          CURRENT_INBOUND=$(echo "${FIREWALL}" | jq '.data[0].rules.inbound // []')
+
+          UPDATED_INBOUND=$(echo "${CURRENT_INBOUND}" | jq \
+            --arg ip "${RUNNER_IP}/32" \
+            'map(if .displayName == "GithubActionsCICD"
+              then . + {"srcCidr": {"ipv4": [$ip], "ipv6": []}, "status": "active"}
+              else .
+              end)')
+
+          PUT_BODY=$(jq -n --argjson inbound "$UPDATED_INBOUND" '{"rules": {"inbound": $inbound}}')
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
+            -H "Content-Type: application/json" \
+            -d "${PUT_BODY}" \
+            "https://api.contabo.com/v1/firewalls/${FIREWALL_ID}")
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Failed to update firewall (HTTP ${HTTP_CODE})"
+            exit 1
+          fi
+
+          echo "Firewall rule activated for ${RUNNER_IP}"
+
       - name: Configure SSH
         env:
           SERVER_SSH_KEY: ${{ secrets.SERVER_SSH_KEY }}
@@ -61,3 +119,55 @@ jobs:
 
       - name: Deploy
         run: rsync -rtvO --delete ./dist/ projectzoe-prod:/opt/projectzoe/staging/client/dist/
+
+      - name: Close firewall
+        if: always() && steps.firewall-open.conclusion == 'success'
+        env:
+          SERVER_CLIENT_ID: ${{ secrets.SERVER_CLIENT_ID }}
+          SERVER_CLIENT_SECRET: ${{ secrets.SERVER_CLIENT_SECRET }}
+          SERVER_API_USER: ${{ secrets.SERVER_API_USER }}
+          SERVER_API_PASSWORD: ${{ secrets.SERVER_API_PASSWORD }}
+          FIREWALL_ID: ${{ secrets.FIREWALL_ID }}
+        run: |
+          TOKEN=$(curl -s \
+            -d "client_id=${SERVER_CLIENT_ID}" \
+            -d "client_secret=${SERVER_CLIENT_SECRET}" \
+            --data-urlencode "username=${SERVER_API_USER}" \
+            --data-urlencode "password=${SERVER_API_PASSWORD}" \
+            -d "grant_type=password" \
+            'https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token' \
+            | jq -r '.access_token')
+
+          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+            echo "Failed to obtain Contabo access token for cleanup"
+            exit 1
+          fi
+
+          FIREWALL=$(curl -s \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
+            "https://api.contabo.com/v1/firewalls/${FIREWALL_ID}")
+
+          CURRENT_INBOUND=$(echo "${FIREWALL}" | jq '.data[0].rules.inbound // []')
+
+          UPDATED_INBOUND=$(echo "${CURRENT_INBOUND}" | jq \
+            'map(if .displayName == "GithubActionsCICD"
+              then . + {"status": "inactive"}
+              else .
+              end)')
+
+          PUT_BODY=$(jq -n --argjson inbound "$UPDATED_INBOUND" '{"rules": {"inbound": $inbound}}')
+
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "x-request-id: $(cat /proc/sys/kernel/random/uuid)" \
+            -H "Content-Type: application/json" \
+            -d "${PUT_BODY}" \
+            "https://api.contabo.com/v1/firewalls/${FIREWALL_ID}")
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Failed to close firewall (HTTP ${HTTP_CODE})"
+            exit 1
+          fi
+
+          echo "Firewall rule deactivated for ${{ steps.firewall-open.outputs.runner_ip }}"


### PR DESCRIPTION
Adds firewall management steps to both production and staging workflows. Before deploying, the GithubActionsCICD rule is activated with the runner's current IP; after deploying (even on failure), the rule is deactivated via the Contabo API.

# Ticket No
- Ticket number here

# Summary of changes
- Summary of changes here

# How should this be tested? [Screenshots, Video or Type instructions]
- How should this be tested here

# Notes for reviewers
- Notes for reviewers here

# Out of scope
-  Out of scope here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Deployment workflows now temporarily allow the GitHub runner through the deployment firewall.
  * Firewall access is automatically revoked after deployment completes.
  * Deployment steps now fail clearly if firewall access cannot be configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->