### PR TITLE
feat:soft delete contact

### DIFF
--- a/src/modules/contacts/ContactDetail.tsx
+++ b/src/modules/contacts/ContactDetail.tsx
@@ -13,6 +13,7 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
+  DialogActions,
   Divider,
   List,
   ListItem,
@@ -34,8 +35,10 @@ import {
   CalendarToday as CalendarIcon,
   Work as WorkIcon,
   ArrowBack as ArrowBackIcon,
+  Delete as DeleteIcon,
 } from '@mui/icons-material';
-import { get } from '../../utils/ajax';
+import { toast } from 'react-toastify';
+import { del, get } from '../../utils/ajax';
 import {
   remoteRoutes,
   localRoutes,
@@ -113,6 +116,8 @@ const ContactDetail = () => {
   const [editDialog, setEditDialog] = useState(false);
   const [editError, setEditError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState(0);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const canViewContactEditActions = hasAnyCapability(user, [
     appPermissions.roleCrmEdit,
   ]);
@@ -152,6 +157,38 @@ const ContactDetail = () => {
     setEditError(null);
     setEditDialog(false);
     fetchContact();
+  };
+
+  const handleDelete = () => {
+    if (!canViewContactEditActions || !contact) {
+      return;
+    }
+    setConfirmDeleteOpen(true);
+  };
+
+  const handleCloseConfirmDelete = () => {
+    setConfirmDeleteOpen(false);
+  };
+
+  const confirmDelete = () => {
+    if (!contact) {
+      return;
+    }
+
+    setDeleting(true);
+    del(
+      `${remoteRoutes.contacts}/${contact.id}`,
+      () => {
+        toast.success('Contact deleted successfully');
+        setConfirmDeleteOpen(false);
+        navigate(localRoutes.contacts);
+      },
+      (error: unknown) => {
+        console.error('Failed to delete contact:', error);
+        toast.error('Failed to delete contact');
+        setDeleting(false);
+      },
+    );
   };
 
   const getInitials = (contact: ContactData) => {
@@ -225,14 +262,26 @@ const ContactDetail = () => {
           Contact Details
         </Typography>
         {canViewContactEditActions ? (
-          <Button
-            variant="contained"
-            startIcon={<EditIcon />}
-            onClick={handleEdit}
-            fullWidth={isMobile}
-          >
-            Edit
-          </Button>
+          <>
+            <Button
+              variant="contained"
+              startIcon={<EditIcon />}
+              onClick={handleEdit}
+              fullWidth={isMobile}
+            >
+              Edit
+            </Button>
+            <Button
+              variant="outlined"
+              color="error"
+              startIcon={<DeleteIcon />}
+              onClick={handleDelete}
+              disabled={deleting}
+              fullWidth={isMobile}
+            >
+              {deleting ? 'Deleting...' : 'Delete'}
+            </Button>
+          </>
         ) : null}
       </Box>
 
@@ -513,6 +562,31 @@ const ContactDetail = () => {
             onError={(message) => setEditError(message || null)}
           />
         </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={confirmDeleteOpen}
+        onClose={handleCloseConfirmDelete}
+        maxWidth="xs"
+      >
+        <DialogTitle>Delete Contact</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete "{fullName}"? 
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseConfirmDelete}>Cancel</Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={confirmDelete}
+            disabled={deleting}
+          >
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
       </Dialog>
     </Box>
   );

--- a/src/modules/contacts/ContactDetail.tsx
+++ b/src/modules/contacts/ContactDetail.tsx
@@ -167,6 +167,9 @@ const ContactDetail = () => {
   };
 
   const handleCloseConfirmDelete = () => {
+    if(deleting){
+      return;
+    }
     setConfirmDeleteOpen(false);
   };
 
@@ -567,7 +570,8 @@ const ContactDetail = () => {
       {/* Delete Confirmation Dialog */}
       <Dialog
         open={confirmDeleteOpen}
-        onClose={handleCloseConfirmDelete}
+        onClose={deleting ? undefined : handleCloseConfirmDelete}
+        disableEscapeKeyDown={deleting}
         maxWidth="xs"
       >
         <DialogTitle>Delete Contact</DialogTitle>
@@ -577,7 +581,7 @@ const ContactDetail = () => {
           </Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCloseConfirmDelete}>Cancel</Button>
+          <Button onClick={handleCloseConfirmDelete} disabled={deleting}>Cancel</Button>
           <Button
             color="error"
             variant="contained"

--- a/src/modules/contacts/Contacts.tsx
+++ b/src/modules/contacts/Contacts.tsx
@@ -10,6 +10,7 @@ import {
   Dialog,
   DialogTitle,
   DialogContent,
+  DialogActions,
   Table,
   TableBody,
   TableCell,
@@ -37,8 +38,16 @@ import {
   MoreVert as MoreVertIcon,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
-import { search } from '../../utils/ajax';
-import { remoteRoutes, localRoutes } from '../../data/constants';
+import { useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
+import { del, search } from '../../utils/ajax';
+import {
+  remoteRoutes,
+  localRoutes,
+  appPermissions,
+} from '../../data/constants';
+import type { RootState } from '../../data/store';
+import { hasAnyCapability } from '../../utils/permissions';
 import ContactForm from './ContactForm';
 import BulkUpload from './BulkUpload';
 import {
@@ -95,6 +104,11 @@ const Contacts = () => {
   const [total, setTotal] = useState<number>(0);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [selectedContact, setSelectedContact] = useState<Contact | null>(null);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
+  const [contactToDelete, setContactToDelete] = useState<Contact | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const { user } = useSelector((state: RootState) => state.core);
+  const canEditContacts = hasAnyCapability(user, [appPermissions.roleCrmEdit]);
   const paginatedContacts = contacts.slice(
     page * rowsPerPage,
     page * rowsPerPage + rowsPerPage,
@@ -223,6 +237,41 @@ const Contacts = () => {
     handleEditClose()
     // Refresh contacts list; keep same pagination
     setFilter((prev) => ({ ...prev }));
+  };
+
+  const handleDelete = () => {
+    if (!selectedContact) return;
+
+    setContactToDelete(selectedContact);
+    setConfirmDeleteOpen(true);
+    handleMenuClose();
+  };
+
+  const handleCloseConfirmDelete = () => {
+    setConfirmDeleteOpen(false);
+    setContactToDelete(null);
+  };
+
+  const confirmDelete = () => {
+    if (!contactToDelete) return;
+
+    setDeleting(true);
+    del(
+      `${remoteRoutes.contacts}/${contactToDelete.id}`,
+      () => {
+        toast.success('Contact deleted successfully');
+        setDeleting(false);
+        setConfirmDeleteOpen(false);
+        setContactToDelete(null);
+        // Refetch so the deleted contact drops out; keep same pagination
+        setFilter((prev) => ({ ...prev }));
+      },
+      (error: unknown) => {
+        console.error('Failed to delete contact:', error);
+        toast.error('Failed to delete contact');
+        setDeleting(false);
+      },
+    );
   };
 
   const getInitials = (name: string) => {
@@ -589,7 +638,37 @@ const Contacts = () => {
       >
         <MenuItem onClick={handleViewDetails}>View Details</MenuItem>
         <MenuItem onClick={handleEdit}>Edit</MenuItem>
+        {canEditContacts ? (
+          <MenuItem onClick={handleDelete} sx={{ color: 'error.main' }}>
+            Delete
+          </MenuItem>
+        ) : null}
       </Menu>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={confirmDeleteOpen}
+        onClose={handleCloseConfirmDelete}
+        maxWidth="xs"
+      >
+        <DialogTitle>Delete Contact</DialogTitle>
+        <DialogContent>
+          <Typography>
+            Are you sure you want to delete "{contactToDelete?.name}"? 
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleCloseConfirmDelete}>Cancel</Button>
+          <Button
+            color="error"
+            variant="contained"
+            onClick={confirmDelete}
+            disabled={deleting}
+          >
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* New Contact Dialog */}
       <Dialog

--- a/src/modules/contacts/Contacts.tsx
+++ b/src/modules/contacts/Contacts.tsx
@@ -248,6 +248,9 @@ const Contacts = () => {
   };
 
   const handleCloseConfirmDelete = () => {
+    if(deleting) {
+      return;
+    }
     setConfirmDeleteOpen(false);
     setContactToDelete(null);
   };
@@ -648,7 +651,8 @@ const Contacts = () => {
       {/* Delete Confirmation Dialog */}
       <Dialog
         open={confirmDeleteOpen}
-        onClose={handleCloseConfirmDelete}
+        onClose={deleting ? undefined : handleCloseConfirmDelete}
+        disableEscapeKeyDown={deleting}
         maxWidth="xs"
       >
         <DialogTitle>Delete Contact</DialogTitle>
@@ -658,7 +662,7 @@ const Contacts = () => {
           </Typography>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleCloseConfirmDelete}>Cancel</Button>
+          <Button onClick={handleCloseConfirmDelete} disabled={deleting}>Cancel</Button>
           <Button
             color="error"
             variant="contained"


### PR DESCRIPTION
# Ticket No
- <ticket-id>

# Summary of changes
- Adds a delete action for contacts, which previously had no delete UI anywhere in the contacts module.
- `Contacts.tsx`: adds a red **Delete** item to the existing row action menu (alongside View Details / Edit), gated on the `CRM_EDIT` capability.
- `ContactDetail.tsx`: adds a **Delete** button beside Edit in the page header, gated on the same `canViewContactEditActions` check already used for Edit. On success it navigates back to the contacts list.
- Both entry points open a MUI confirmation `Dialog` (title / body / `DialogActions` with Cancel + a red contained Delete) following the same pattern as the delete-user and delete-role flows in `admin/users/UserManagement.tsx` — no `window.confirm`.
- The confirm button shows `Deleting...` and is disabled while the request is in flight; the result is reported with `toast.success` / `toast.error`, consistent with the rest of the app.
- The list refetches after a successful delete via the existing `setFilter((prev) => ({ ...prev }))` mechanism, preserving the current pagination.
- Copy in the dialog states that the contact is removed from listings and group rosters but their history is kept, so the soft-delete semantics are visible to the user.

# How should this be tested? [Screenshots, Video or Type instructions]
- Point the client at a server branch that includes the matching soft-delete API change (the paired server PR), then sign in as a user **with** the `CRM_EDIT` capability.
- **List page:** go to Contacts → click the ⋮ menu on any row → **Delete**. Confirm the dialog shows the contact's name. Click **Cancel** — the dialog closes and the contact is still listed. Reopen and click **Delete** — a success toast appears and the contact disappears from the list without the page jumping back to page 1.
- **Detail page:** open a contact → click **Delete** in the header → confirm. A success toast appears and you are redirected to the contacts list, with the contact absent.
- **Pending state:** throttle the network in devtools and confirm the Delete button reads `Deleting...` and is disabled while the request is in flight.
- **Permissions:** sign in as a user **without** `CRM_EDIT` and confirm the Delete menu item and the Delete button are both absent on the list and detail pages.
- **Error path:** stop the API (or block the DELETE in devtools) and confirm an error toast appears, the dialog stays open, and the button returns to `Delete`.
- Type checks: `npx tsc --noEmit -p tsconfig.app.json` (clean).

# Notes for reviewers
- This PR depends on the paired **server** PR for the `DELETE /api/crm/contacts/:id` behaviour. Merged alone, the button will call a hard-delete endpoint.
- Delete on the list page is gated on `CRM_EDIT` while the existing **Edit** item in that same menu is not gated. I deliberately did not loosen the new action to match; tightening the existing Edit item felt out of scope for this PR but is worth a follow-up.
- In `ContactDetail.tsx` the Edit button was previously a bare `{cond ? <Button/> : null}`; it is now wrapped in a fragment with the new Delete button. The diff looks larger than the change is — the Edit button itself is unchanged apart from indentation.
- `ContactDetail.tsx` still reports 6 pre-existing eslint errors (`no-explicit-any` in `mapApiResponse`, and `fetchContact` accessed before declaration). The count is unchanged by this PR; none of them are in the new code.
- No new dependencies. `del` from `utils/ajax` and `toast` from `react-toastify` were both already in use elsewhere in the app.

# Out of scope
- Any "restore" / undelete UI, or a view listing deleted contacts. The server keeps the row, but nothing in the client can bring one back yet.
- Bulk delete or multi-select on the contacts list.
- Gating the pre-existing **Edit** action in the row menu behind a capability check.
- Fixing the pre-existing lint errors in `ContactDetail.tsx`.
- Any change to what happens to a deleted contact's linked user account (see the server PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete contacts from the contact details page and contacts list.
  * Added confirmation prompts to help prevent accidental deletions.
  * Added success and error notifications during deletion.
  * The contacts list now refreshes automatically after successful deletion.
  * Delete actions are shown only to users with editing permissions.
  * Prevented closing the confirmation prompt while deletion is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->