### PR TITLE
finance module fix client

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -192,6 +192,7 @@ export const remoteRoutes = {
   financialAccounts: `${apiBaseUrl}/api/finance/accounts`,
   financialTransactions: `${apiBaseUrl}/api/finance/transactions`,
   financialReconciliation: `${apiBaseUrl}/api/finance/reconciliation`,
+  financialReports: `${apiBaseUrl}/api/finance/reports`,
   financialDistributions: `${apiBaseUrl}/api/finance/distributions`,
   financialCategoryRules: `${apiBaseUrl}/api/finance/category-rules`,
 

--- a/src/modules/finance/Distributions.tsx
+++ b/src/modules/finance/Distributions.tsx
@@ -35,7 +35,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import type { Dayjs } from 'dayjs';
 import { toast } from 'react-toastify';
-import { get, post, put } from '../../utils/ajax';
+import { get, post } from '../../utils/ajax';
 import { remoteRoutes } from '../../data/constants';
 import type { DistributionBatch, BatchStatus } from './types';
 
@@ -86,7 +86,7 @@ const Distributions = () => {
   const fetchBatches = () => {
     setLoading(true);
     get(
-      remoteRoutes.financialDistributions,
+      `${remoteRoutes.financialDistributions}/batches`,
       (data: DistributionBatch[]) => {
         setBatches(data);
         setLoading(false);
@@ -133,8 +133,8 @@ const Distributions = () => {
   };
 
   const handleSubmitForApproval = (batchId: number) => {
-    put(
-      `${remoteRoutes.financialDistributions}/${batchId}/submit`,
+    post(
+      `${remoteRoutes.financialDistributions}/batches/${batchId}/submit`,
       {},
       () => {
         toast.success('Batch submitted for approval');
@@ -147,8 +147,8 @@ const Distributions = () => {
   };
 
   const handleApprove = (batchId: number) => {
-    put(
-      `${remoteRoutes.financialDistributions}/${batchId}/approve`,
+    post(
+      `${remoteRoutes.financialDistributions}/batches/${batchId}/approve`,
       {},
       () => {
         toast.success('Batch approved');
@@ -165,8 +165,8 @@ const Distributions = () => {
       return;
     }
 
-    put(
-      `${remoteRoutes.financialDistributions}/${batchId}/execute`,
+    post(
+      `${remoteRoutes.financialDistributions}/batches/${batchId}/execute`,
       {},
       () => {
         toast.success('Distribution executed');
@@ -177,6 +177,13 @@ const Distributions = () => {
       }
     );
   };
+
+/**
+   * Postgres numeric columns arrive as strings, so formatting has to coerce
+   * first — otherwise "1500.00" renders unseparated, and a null throws.
+   */
+  const money = (value: number | string | null | undefined) =>
+    Number(value ?? 0).toLocaleString();
 
   const toggleExpand = (batchId: number) => {
     setExpandedBatch(expandedBatch === batchId ? null : batchId);
@@ -242,7 +249,7 @@ const Distributions = () => {
                   </Box>
                   <Box display="flex" alignItems="center" gap={2}>
                     <Typography variant="h6">
-                      {batch.totalAmount.toLocaleString()}
+                      {money(batch.totalAmount)}
                     </Typography>
                     <Chip
                       icon={getStatusIcon(batch.status)}
@@ -305,34 +312,65 @@ const Distributions = () => {
                           </TableRow>
                         </TableHead>
                         <TableBody>
-                          {batch.distributions.map((dist) => (
-                            <TableRow key={dist.id}>
-                              <TableCell>
-                                <Chip label={dist.category} size="small" variant="outlined" />
-                              </TableCell>
-                              <TableCell>{dist.purpose}</TableCell>
-                              <TableCell>
-                                {dist.toAccount?.name || dist.toLocation?.name || '-'}
-                              </TableCell>
-                              <TableCell align="right">
-                                {dist.percentage ? `${dist.percentage}%` : '-'}
-                              </TableCell>
-                              <TableCell align="right">
-                                {dist.amount.toLocaleString()}
-                              </TableCell>
-                              <TableCell>
-                                {dist.transferred ? (
-                                  <Chip
-                                    label="Transferred"
-                                    color="success"
-                                    size="small"
-                                  />
-                                ) : (
-                                  <Chip label="Pending" size="small" variant="outlined" />
-                                )}
+                          {(batch.distributions ?? []).length === 0 ? (
+                            <TableRow>
+                              <TableCell colSpan={6}>
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                  py={1}
+                                >
+                                  No distribution lines on this batch yet.
+                                </Typography>
                               </TableCell>
                             </TableRow>
-                          ))}
+                          ) : (
+                            (batch.distributions ?? []).map((dist) => (
+                              <TableRow key={dist.id}>
+                                <TableCell>
+                                  <Chip
+                                    label={dist.category}
+                                    size="small"
+                                    variant="outlined"
+                                  />
+                                </TableCell>
+                                <TableCell>{dist.description || '-'}</TableCell>
+                                <TableCell>
+                                  {dist.targetAccount?.name ||
+                                    dist.targetGroup?.name ||
+                                    '-'}
+                                </TableCell>
+                                <TableCell align="right">
+                                  {dist.percentage != null
+                                    ? `${Number(dist.percentage)}%`
+                                    : '-'}
+                                </TableCell>
+                                <TableCell align="right">
+                                  {money(dist.amount)}
+                                </TableCell>
+                                <TableCell>
+                                  {/*
+                                    A line is only actually paid out once its
+                                    batch has been executed — the entity has no
+                                    per-line transferred flag.
+                                  */}
+                                  {batch.status === 'EXECUTED' ? (
+                                    <Chip
+                                      label="Transferred"
+                                      color="success"
+                                      size="small"
+                                    />
+                                  ) : (
+                                    <Chip
+                                      label="Pending"
+                                      size="small"
+                                      variant="outlined"
+                                    />
+                                  )}
+                                </TableCell>
+                              </TableRow>
+                            ))
+                          )}
                         </TableBody>
                       </Table>
                     </TableContainer>

--- a/src/modules/finance/Distributions.tsx
+++ b/src/modules/finance/Distributions.tsx
@@ -37,7 +37,7 @@ import type { Dayjs } from 'dayjs';
 import { toast } from 'react-toastify';
 import { get, post } from '../../utils/ajax';
 import { remoteRoutes } from '../../data/constants';
-import type { DistributionBatch, BatchStatus } from './types';
+import type { DistributionBatch, Distribution, BatchStatus } from './types';
 
 const getStatusColor = (status: BatchStatus): 'default' | 'warning' | 'info' | 'success' => {
   switch (status) {
@@ -73,6 +73,13 @@ const Distributions = () => {
   const [batches, setBatches] = useState<DistributionBatch[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedBatch, setExpandedBatch] = useState<number | null>(null);
+  // The list endpoint returns batches without their lines; details are
+  // fetched the first time a batch is expanded and cached here.
+  const [batchDetails, setBatchDetails] = useState<
+    Record<number, Distribution[]>
+  >({});
+  const [loadingDetail, setLoadingDetail] = useState<number | null>(null);
+  const [executingId, setExecutingId] = useState<number | null>(null);
 
   // Create dialog
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -84,6 +91,8 @@ const Distributions = () => {
   });
 
   const fetchBatches = () => {
+    // Batch contents may have changed; drop the cache so an expand refetches.
+    setBatchDetails({});
     setLoading(true);
     get(
       `${remoteRoutes.financialDistributions}/batches`,
@@ -165,14 +174,17 @@ const Distributions = () => {
       return;
     }
 
+    setExecutingId(batchId);
     post(
       `${remoteRoutes.financialDistributions}/batches/${batchId}/execute`,
       {},
       () => {
+        setExecutingId(null);
         toast.success('Distribution executed');
         fetchBatches();
       },
       () => {
+        setExecutingId(null);
         toast.error('Failed to execute distribution');
       }
     );
@@ -186,7 +198,28 @@ const Distributions = () => {
     Number(value ?? 0).toLocaleString();
 
   const toggleExpand = (batchId: number) => {
-    setExpandedBatch(expandedBatch === batchId ? null : batchId);
+    const next = expandedBatch === batchId ? null : batchId;
+    setExpandedBatch(next);
+
+    if (next === null || batchDetails[batchId]) {
+      return;
+    }
+
+    setLoadingDetail(batchId);
+    get(
+      `${remoteRoutes.financialDistributions}/batches/${batchId}`,
+      (data: DistributionBatch) => {
+        setBatchDetails((prev) => ({
+          ...prev,
+          [batchId]: data.distributions ?? [],
+        }));
+        setLoadingDetail(null);
+      },
+      () => {
+        setLoadingDetail(null);
+        toast.error('Failed to load distribution lines');
+      }
+    );
   };
 
   if (loading) {
@@ -285,12 +318,13 @@ const Distributions = () => {
                         size="small"
                         variant="contained"
                         startIcon={<PlayArrowIcon />}
+                        disabled={executingId === batch.id}
                         onClick={(e) => {
                           e.stopPropagation();
                           handleExecute(batch.id);
                         }}
                       >
-                        Execute
+                        {executingId === batch.id ? 'Executing...' : 'Execute'}
                       </Button>
                     )}
                   </Box>
@@ -312,7 +346,21 @@ const Distributions = () => {
                           </TableRow>
                         </TableHead>
                         <TableBody>
-                          {(batch.distributions ?? []).length === 0 ? (
+                          {batchDetails[batch.id] === undefined ? (
+                            <TableRow>
+                              <TableCell colSpan={6}>
+                                <Typography
+                                  variant="body2"
+                                  color="text.secondary"
+                                  py={1}
+                                >
+                                  {loadingDetail === batch.id
+                                    ? 'Loading distribution lines…'
+                                    : 'Distribution lines not loaded.'}
+                                </Typography>
+                              </TableCell>
+                            </TableRow>
+                          ) : batchDetails[batch.id].length === 0 ? (
                             <TableRow>
                               <TableCell colSpan={6}>
                                 <Typography
@@ -325,7 +373,7 @@ const Distributions = () => {
                               </TableCell>
                             </TableRow>
                           ) : (
-                            (batch.distributions ?? []).map((dist) => (
+                            batchDetails[batch.id].map((dist) => (
                               <TableRow key={dist.id}>
                                 <TableCell>
                                   <Chip

--- a/src/modules/finance/FinancialReports.tsx
+++ b/src/modules/finance/FinancialReports.tsx
@@ -35,12 +35,13 @@ import {
   Refresh as RefreshIcon,
 } from '@mui/icons-material';
 import { toast } from 'react-toastify';
-import { get } from '../../utils/ajax';
+import { get, downLoad } from '../../utils/ajax';
 import { remoteRoutes } from '../../data/constants';
 import type { ReconciliationSummary, DistributionSummary, FinancialAccount } from './types';
 
 const FinancialReports = () => {
   const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
   const [accounts, setAccounts] = useState<FinancialAccount[]>([]);
 
   // Filters
@@ -60,8 +61,8 @@ const FinancialReports = () => {
     setLoading(true);
 
     const params = new URLSearchParams({
-      dateFrom: dateFrom.format('YYYY-MM-DD'),
-      dateTo: dateTo.format('YYYY-MM-DD'),
+      startDate: dateFrom.format('YYYY-MM-DD'),
+      endDate: dateTo.format('YYYY-MM-DD'),
     });
     if (accountFilter !== 'ALL') {
       params.append('accountId', accountFilter.toString());
@@ -69,7 +70,7 @@ const FinancialReports = () => {
 
     // Fetch reconciliation summary
     get(
-      `${remoteRoutes.financialReconciliation}/summary?${params.toString()}`,
+      `${remoteRoutes.financialReports}/summary?${params.toString()}`,
       (data: ReconciliationSummary) => {
         setReconciliationSummary(data);
       },
@@ -80,7 +81,7 @@ const FinancialReports = () => {
 
     // Fetch distribution summary
     get(
-      `${remoteRoutes.financialDistributions}/summary?${params.toString()}`,
+      `${remoteRoutes.financialReports}/distributions?${params.toString()}`,
       (data: DistributionSummary) => {
         setDistributionSummary(data);
         setLoading(false);
@@ -113,29 +114,44 @@ const FinancialReports = () => {
   const handleExport = () => {
     if (!dateFrom || !dateTo) return;
 
-    const params = new URLSearchParams({
-      dateFrom: dateFrom.format('YYYY-MM-DD'),
-      dateTo: dateTo.format('YYYY-MM-DD'),
-      format: 'csv',
-    });
+    const from = dateFrom.format('YYYY-MM-DD');
+    const to = dateTo.format('YYYY-MM-DD');
+
+    const params = new URLSearchParams({ startDate: from, endDate: to });
     if (accountFilter !== 'ALL') {
       params.append('accountId', accountFilter.toString());
     }
 
-    window.open(
-      `${remoteRoutes.financialReconciliation}/export?${params.toString()}`,
-      '_blank'
+    setExporting(true);
+
+    // Fetched through the shared client so the request carries the bearer
+    // token, then saved from the blob. A window.open would open an
+    // unauthenticated tab and be rejected.
+    downLoad(
+      `${remoteRoutes.financialReports}/export?${params.toString()}`,
+      (data: Blob) => {
+        const url = URL.createObjectURL(data);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `reconciliation-${from}-to-${to}.csv`;
+        link.click();
+        URL.revokeObjectURL(url);
+        setExporting(false);
+        toast.success('Export downloaded');
+      },
+      () => {
+        setExporting(false);
+        toast.error('Export failed');
+      }
     );
-    toast.success('Export started');
   };
 
   // Prepare chart data
-  const categoryData = reconciliationSummary?.byCategory
-    ? Object.entries(reconciliationSummary.byCategory).map(([category, amount]) => ({
-        label: category,
-        value: amount,
-      }))
-    : [];
+  const categoryData =
+    reconciliationSummary?.byCategory?.map(({ category, amount }) => ({
+      label: category,
+      value: amount,
+    })) ?? [];
 
   const locationData = distributionSummary?.byLocation
     ? Object.entries(distributionSummary.byLocation).map(([location, amount]) => ({
@@ -157,8 +173,9 @@ const FinancialReports = () => {
               variant="outlined"
               startIcon={<DownloadIcon />}
               onClick={handleExport}
+              disabled={exporting}
             >
-              Export CSV
+              {exporting ? 'Exporting...' : 'Export CSV'}
             </Button>
           </Box>
         </Box>
@@ -214,10 +231,10 @@ const FinancialReports = () => {
                 <Card>
                   <CardContent>
                     <Typography variant="body2" color="text.secondary">
-                      Total Imported
+                      Total Transactions
                     </Typography>
                     <Typography variant="h4">
-                      {reconciliationSummary?.totalImported.toLocaleString() || 0}
+                      {reconciliationSummary?.totalTransactions?.toLocaleString() ?? 0}
                     </Typography>
                   </CardContent>
                 </Card>
@@ -226,10 +243,10 @@ const FinancialReports = () => {
                 <Card>
                   <CardContent>
                     <Typography variant="body2" color="text.secondary">
-                      Matched
+                      Reconciled
                     </Typography>
                     <Typography variant="h4" color="success.main">
-                      {reconciliationSummary?.totalMatched.toLocaleString() || 0}
+                      {reconciliationSummary?.reconciledCount?.toLocaleString() ?? 0}
                     </Typography>
                   </CardContent>
                 </Card>
@@ -241,7 +258,7 @@ const FinancialReports = () => {
                       Pending
                     </Typography>
                     <Typography variant="h4" color="warning.main">
-                      {reconciliationSummary?.totalPending.toLocaleString() || 0}
+                      {reconciliationSummary?.pendingCount?.toLocaleString() ?? 0}
                     </Typography>
                   </CardContent>
                 </Card>
@@ -254,7 +271,7 @@ const FinancialReports = () => {
                     </Typography>
                     <Typography variant="h4">
                       {reconciliationSummary?.matchRate
-                        ? `${Math.round(reconciliationSummary.matchRate * 100)}%`
+                        ? `${Math.round(reconciliationSummary.matchRate)}%`
                         : '0%'}
                     </Typography>
                   </CardContent>

--- a/src/modules/finance/ImportTransactions.tsx
+++ b/src/modules/finance/ImportTransactions.tsx
@@ -31,8 +31,8 @@ import {
   Error as ErrorIcon,
 } from '@mui/icons-material';
 import { toast } from 'react-toastify';
-import { get, post } from '../../utils/ajax';
-import { remoteRoutes, AUTH_TOKEN_KEY } from '../../data/constants';
+import { get, post, postFile } from '../../utils/ajax';
+import { remoteRoutes } from '../../data/constants';
 import type { FinancialAccount, ParsedTransaction, TransactionCategory, TransactionImportConfig } from './types';
 
 const steps = ['Select Account', 'Upload File', 'Review & Import'];
@@ -135,28 +135,24 @@ const ImportTransactions = () => {
     formData.append('defaultCategory', config.defaultCategory);
     formData.append('applyServiceTimeRules', config.applyServiceTimeRules.toString());
 
-    const token = localStorage.getItem(AUTH_TOKEN_KEY);
-
-    fetch(`${remoteRoutes.financialTransactions}/parse`, {
-      method: 'POST',
-      body: formData,
-      headers: {
-        ...(token ? { Authorization: `Bearer ${token}` } : {}),
-      },
-    })
-      .then((res) => {
-        if (!res.ok) throw new Error('Failed to parse file');
-        return res.json();
-      })
-      .then((data: ParsedTransaction[]) => {
+    // Goes through the shared client so the request picks up the auth header,
+    // the timeout and the app's session-expiry handling, rather than a bare
+    // fetch that reimplements only the token.
+    postFile(
+      `${remoteRoutes.financialTransactions}/parse`,
+      formData,
+      (data: ParsedTransaction[]) => {
         setParsedTransactions(data);
         setActiveStep(2);
         setParsing(false);
-      })
-      .catch((err) => {
-        setParseError(err.message || 'Failed to parse file');
+      },
+      (err: unknown) => {
+        setParseError(
+          err instanceof Error ? err.message : 'Failed to parse file',
+        );
         setParsing(false);
-      });
+      },
+    );
   };
 
   const handleImport = () => {
@@ -395,6 +391,24 @@ const ImportTransactions = () => {
                   {importResult.errors.length > 0 &&
                     `, ${importResult.errors.length} failed`}
                 </Typography>
+
+                {importResult.errors.length > 0 && (
+                  <Alert severity="warning" sx={{ mb: 3, textAlign: 'left' }}>
+                    <Typography variant="subtitle2" gutterBottom>
+                      Rows that could not be imported
+                    </Typography>
+                    {/* Each message names the offending row, so showing them
+                        lets the user fix the file instead of guessing. */}
+                    <Box component="ul" sx={{ m: 0, pl: 2 }}>
+                      {importResult.errors.map((message) => (
+                        <li key={message}>
+                          <Typography variant="body2">{message}</Typography>
+                        </li>
+                      ))}
+                    </Box>
+                  </Alert>
+                )}
+
                 <Button variant="contained" onClick={handleReset}>
                   Import More
                 </Button>

--- a/src/modules/finance/ImportTransactions.tsx
+++ b/src/modules/finance/ImportTransactions.tsx
@@ -59,7 +59,7 @@ const ImportTransactions = () => {
 
   // Step 3: Parsed data
   const [parsedTransactions, setParsedTransactions] = useState<ParsedTransaction[]>([]);
-  const [importResult, setImportResult] = useState<{ imported: number; errors: number } | null>(null);
+  const [importResult, setImportResult] = useState<{ imported: number; errors: string[] } | null>(null);
 
   useEffect(() => {
     get(
@@ -80,19 +80,17 @@ const ImportTransactions = () => {
   }, []);
 
   const handleFileSelect = (selectedFile: File) => {
-    const validTypes = [
-      'text/csv',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'application/vnd.ms-excel',
-    ];
-    const validExtensions = ['.csv', '.xlsx', '.xls'];
+    // Validated by extension rather than MIME type: browsers report CSV
+    // inconsistently (text/csv, application/vnd.ms-excel, or empty depending
+    // on the OS), and the server picks its reader by extension too.
+    const validExtensions = ['.csv', '.xlsx'];
 
-    const hasValidExtension = validExtensions.some(ext =>
-      selectedFile.name.toLowerCase().endsWith(ext)
+    const hasValidExtension = validExtensions.some((ext) =>
+      selectedFile.name.toLowerCase().endsWith(ext),
     );
 
-    if (!validTypes.includes(selectedFile.type) && !hasValidExtension) {
-      setParseError('Please upload a CSV or Excel file');
+    if (!hasValidExtension) {
+      setParseError('Please upload a .csv or .xlsx file');
       return;
     }
 
@@ -176,7 +174,7 @@ const ImportTransactions = () => {
         accountId: config.accountId,
         transactions: validTransactions,
       },
-      (result: { imported: number; errors: number }) => {
+      (result: { imported: number; errors: string[] }) => {
         setImportResult(result);
         toast.success(`Imported ${result.imported} transactions`);
         setImporting(false);
@@ -314,7 +312,7 @@ const ImportTransactions = () => {
               type="file"
               ref={fileInputRef}
               onChange={handleFileInputChange}
-              accept=".csv,.xlsx,.xls"
+              accept=".csv,.xlsx"
               style={{ display: 'none' }}
             />
 
@@ -343,7 +341,7 @@ const ImportTransactions = () => {
               <Typography variant="body1" mb={1}>
                 {isDragging
                   ? 'Drop the file here...'
-                  : 'Drag and drop a CSV or Excel file here'}
+                  : 'Drag and drop a .csv or .xlsx file here'}
               </Typography>
               <Typography variant="body2" color="text.secondary">
                 or click to select a file
@@ -394,7 +392,8 @@ const ImportTransactions = () => {
                 </Typography>
                 <Typography color="text.secondary" mb={3}>
                   {importResult.imported} transactions imported
-                  {importResult.errors > 0 && `, ${importResult.errors} errors`}
+                  {importResult.errors.length > 0 &&
+                    `, ${importResult.errors.length} failed`}
                 </Typography>
                 <Button variant="contained" onClick={handleReset}>
                   Import More
@@ -428,6 +427,7 @@ const ImportTransactions = () => {
                         <TableCell>Sender</TableCell>
                         <TableCell align="right">Amount</TableCell>
                         <TableCell>Category</TableCell>
+                        <TableCell>Why</TableCell>
                         <TableCell>Status</TableCell>
                       </TableRow>
                     </TableHead>
@@ -449,6 +449,11 @@ const ImportTransactions = () => {
                           </TableCell>
                           <TableCell>
                             <Chip label={tx.category} size="small" />
+                          </TableCell>
+                          <TableCell>
+                            <Typography variant="caption" color="text.secondary">
+                              {tx.matchedRule || '-'}
+                            </Typography>
                           </TableCell>
                           <TableCell>
                             {tx.isValid ? (

--- a/src/modules/finance/Reconciliation.tsx
+++ b/src/modules/finance/Reconciliation.tsx
@@ -646,7 +646,9 @@ const Reconciliation = () => {
                         )}
                       </TableCell>
                       <TableCell align="right">
-                        {tx.status === 'PENDING' && !tx.reconciliationMatch && (
+                        {tx.status === 'PENDING' &&
+                          (!tx.reconciliationMatch ||
+                            tx.reconciliationMatch.status === 'REJECTED') && (
                           <Tooltip title="Match to contact">
                             <IconButton
                               size="small"

--- a/src/modules/finance/Reconciliation.tsx
+++ b/src/modules/finance/Reconciliation.tsx
@@ -113,6 +113,9 @@ const Reconciliation = () => {
   const [running, setRunning] = useState(false);
   const [approving, setApproving] = useState(false);
   const [selectedMatchIds, setSelectedMatchIds] = useState<number[]>([]);
+  // Transaction whose approve/reject request is in flight, so both controls
+  // on that row can be disabled without freezing the whole table.
+  const [resolvingId, setResolvingId] = useState<number | null>(null);
 
   const fetchTransactions = () => {
     setLoading(true);
@@ -322,30 +325,36 @@ const Reconciliation = () => {
   };
 
   const handleApproveMatch = (transactionId: number) => {
+    setResolvingId(transactionId);
     put(
       `${remoteRoutes.financialReconciliation}/approve/${transactionId}`,
       {},
       () => {
         toast.success('Match approved');
+        setResolvingId(null);
         dropFromSelection(transactionId);
         fetchTransactions();
       },
       () => {
+        setResolvingId(null);
         toast.error('Failed to approve match');
       }
     );
   };
 
   const handleRejectMatch = (transactionId: number) => {
+    setResolvingId(transactionId);
     put(
       `${remoteRoutes.financialReconciliation}/reject/${transactionId}`,
       {},
       () => {
         toast.success('Match rejected');
+        setResolvingId(null);
         dropFromSelection(transactionId);
         fetchTransactions();
       },
       () => {
+        setResolvingId(null);
         toast.error('Failed to reject match');
       }
     );
@@ -570,6 +579,13 @@ const Reconciliation = () => {
                             onChange={() =>
                               toggleMatchSelection(tx.reconciliationMatch!.id)
                             }
+                            slotProps={{
+                              input: {
+                                'aria-label': `Select match for ${
+                                  tx.senderName || 'transaction'
+                                } ${tx.amount}`,
+                              },
+                            }}
                           />
                         )}
                       </TableCell>
@@ -653,6 +669,7 @@ const Reconciliation = () => {
                                 <IconButton
                                   size="small"
                                   color="success"
+                                  disabled={resolvingId === tx.id}
                                   onClick={() => handleApproveMatch(tx.id)}
                                 >
                                   <CheckCircleIcon />
@@ -662,6 +679,7 @@ const Reconciliation = () => {
                                 <IconButton
                                   size="small"
                                   color="error"
+                                  disabled={resolvingId === tx.id}
                                   onClick={() => handleRejectMatch(tx.id)}
                                 >
                                   <WarningIcon />

--- a/src/modules/finance/Reconciliation.tsx
+++ b/src/modules/finance/Reconciliation.tsx
@@ -29,6 +29,7 @@ import {
   Tab,
   Tooltip,
   LinearProgress,
+  Checkbox,
 } from '@mui/material';
 import {
   Search as SearchIcon,
@@ -37,6 +38,8 @@ import {
   Person as PersonIcon,
   Link as LinkIcon,
   Refresh as RefreshIcon,
+  AutoAwesome as AutoMatchIcon,
+  DoneAll as ApproveAllIcon,
 } from '@mui/icons-material';
 import { toast } from 'react-toastify';
 import { get, post, put } from '../../utils/ajax';
@@ -82,6 +85,12 @@ const getStatusColor = (status: TransactionStatus): 'warning' | 'success' | 'err
   }
 };
 
+/**
+ * Matches at or above this score are the ones "Approve All High Confidence"
+ * acts on, per the reconciliation tutorial.
+ */
+const HIGH_CONFIDENCE = 90;
+
 const Reconciliation = () => {
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [accounts, setAccounts] = useState<FinancialAccount[]>([]);
@@ -99,6 +108,11 @@ const Reconciliation = () => {
   const [contacts, setContacts] = useState<ContactOption[]>([]);
   const [selectedContact, setSelectedContact] = useState<ContactOption | null>(null);
   const [saving, setSaving] = useState(false);
+
+  // Auto-match and bulk approval
+  const [running, setRunning] = useState(false);
+  const [approving, setApproving] = useState(false);
+  const [selectedMatchIds, setSelectedMatchIds] = useState<number[]>([]);
 
   const fetchTransactions = () => {
     setLoading(true);
@@ -133,6 +147,114 @@ const Reconciliation = () => {
     fetchAccounts();
     fetchTransactions();
   }, [statusFilter, accountFilter]);
+
+  // Selections are only meaningful against the rows on screen. Without this,
+  // ticking matches on one account, switching accounts and approving would
+  // silently approve the hidden ones.
+  useEffect(() => {
+    setSelectedMatchIds([]);
+  }, [statusFilter, accountFilter, search]);
+
+  /**
+   * Runs the matching engine over one account. The endpoint needs a specific
+   * account, so this is only offered once the account filter is narrowed.
+   */
+  const handleRunAutoMatch = () => {
+    if (accountFilter === 'ALL') {
+      toast.info('Choose an account first — auto-match runs one account at a time');
+      return;
+    }
+
+    setRunning(true);
+    post(
+      `${remoteRoutes.financialReconciliation}/run`,
+      {
+        accountId: accountFilter,
+        minConfidenceThreshold: 60,
+      },
+      (result: {
+        processed: number;
+        matched: number;
+        autoApproved: number;
+        errors: string[];
+      }) => {
+        setRunning(false);
+        toast.success(
+          `Matched ${result.matched} of ${result.processed} transactions`,
+        );
+        if (result.errors?.length) {
+          toast.warning(`${result.errors.length} could not be matched`);
+        }
+        setSelectedMatchIds([]);
+        fetchTransactions();
+      },
+      (err: unknown) => {
+        setRunning(false);
+        toast.error(err instanceof Error ? err.message : 'Auto-match failed');
+      },
+    );
+  };
+
+  /** Removes a transaction's match from the selection once it is resolved. */
+  const dropFromSelection = (transactionId: number) => {
+    const matchId = transactions.find((tx) => tx.id === transactionId)
+      ?.reconciliationMatch?.id;
+
+    if (matchId) {
+      setSelectedMatchIds((prev) => prev.filter((id) => id !== matchId));
+    }
+  };
+
+  const toggleMatchSelection = (matchId: number) => {
+    setSelectedMatchIds((prev) =>
+      prev.includes(matchId)
+        ? prev.filter((id) => id !== matchId)
+        : [...prev, matchId],
+    );
+  };
+
+  /** Ticks every pending match scoring at or above the high-confidence mark. */
+  const selectHighConfidence = () => {
+    setSelectedMatchIds(
+      pendingMatches
+        .filter((match) => (match.confidenceScore ?? 0) >= HIGH_CONFIDENCE)
+        .map((match) => match.id),
+    );
+  };
+
+  const handleBulkApprove = () => {
+    // Belt and braces: only ever submit ids that are still pending and on
+    // screen, even if something changed between selection and click.
+    const visibleIds = selectedMatchIds.filter((id) =>
+      pendingMatches.some((match) => match.id === id),
+    );
+
+    if (visibleIds.length === 0) {
+      setSelectedMatchIds([]);
+      return;
+    }
+
+    setApproving(true);
+    post(
+      `${remoteRoutes.financialReconciliation}/bulk-approve`,
+      { matchIds: visibleIds },
+      (result: { approved: number; errors: string[] }) => {
+        setApproving(false);
+        toast.success(`Approved ${result.approved} matches`);
+        if (result.errors?.length) {
+          toast.warning(`${result.errors.length} could not be approved`);
+        }
+        setSelectedMatchIds([]);
+        fetchTransactions();
+      },
+      (err: unknown) => {
+        setApproving(false);
+        toast.error(
+          err instanceof Error ? err.message : 'Bulk approval failed',
+        );
+      },
+    );
+  };
 
   const handleOpenMatchDialog = (transaction: Transaction) => {
     setSelectedTransaction(transaction);
@@ -180,7 +302,7 @@ const Reconciliation = () => {
     setSaving(true);
 
     post(
-      `${remoteRoutes.financialReconciliation}/match`,
+      `${remoteRoutes.financialReconciliation}/matches`,
       {
         transactionId: selectedTransaction.id,
         contactId: contact.id,
@@ -205,6 +327,7 @@ const Reconciliation = () => {
       {},
       () => {
         toast.success('Match approved');
+        dropFromSelection(transactionId);
         fetchTransactions();
       },
       () => {
@@ -219,6 +342,7 @@ const Reconciliation = () => {
       {},
       () => {
         toast.success('Match rejected');
+        dropFromSelection(transactionId);
         fetchTransactions();
       },
       () => {
@@ -234,6 +358,17 @@ const Reconciliation = () => {
       tx.narration?.toLowerCase().includes(search.toLowerCase())
   );
 
+  // Matches awaiting a decision — what the bulk controls operate on.
+  const pendingMatches = filteredTransactions
+    .map((tx) => tx.reconciliationMatch)
+    .filter(
+      (match): match is NonNullable<Transaction['reconciliationMatch']> =>
+        !!match && match.status === 'PENDING',
+    );
+  const highConfidenceCount = pendingMatches.filter(
+    (match) => (match.confidenceScore ?? 0) >= HIGH_CONFIDENCE,
+  ).length;
+
   const pendingCount = transactions.filter((tx) => tx.status === 'PENDING').length;
   const reconciledCount = transactions.filter((tx) => tx.status === 'RECONCILED').length;
 
@@ -241,9 +376,29 @@ const Reconciliation = () => {
     <Container maxWidth="lg">
       <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
         <Typography variant="h4">Reconciliation</Typography>
-        <Button startIcon={<RefreshIcon />} onClick={fetchTransactions}>
-          Refresh
-        </Button>
+        <Box display="flex" gap={1} flexWrap="wrap">
+          <Tooltip
+            title={
+              accountFilter === 'ALL'
+                ? 'Choose an account to run auto-match'
+                : 'Find contacts for unmatched transactions on this account'
+            }
+          >
+            <span>
+              <Button
+                variant="contained"
+                startIcon={<AutoMatchIcon />}
+                onClick={handleRunAutoMatch}
+                disabled={running || accountFilter === 'ALL'}
+              >
+                {running ? 'Matching...' : 'Run Auto-Match'}
+              </Button>
+            </span>
+          </Tooltip>
+          <Button startIcon={<RefreshIcon />} onClick={fetchTransactions}>
+            Refresh
+          </Button>
+        </Box>
       </Box>
 
       {/* Summary Cards */}
@@ -328,6 +483,49 @@ const Reconciliation = () => {
           </FormControl>
         </Box>
 
+        {/* Bulk approval */}
+        {pendingMatches.length > 0 && (
+          <Box
+            display="flex"
+            alignItems="center"
+            gap={2}
+            mb={2}
+            p={1.5}
+            sx={{ bgcolor: 'action.hover', borderRadius: 1 }}
+            flexWrap="wrap"
+          >
+            <Typography variant="body2">
+              {selectedMatchIds.length > 0
+                ? `${selectedMatchIds.length} selected`
+                : `${pendingMatches.length} awaiting approval`}
+            </Typography>
+            <Button
+              size="small"
+              onClick={selectHighConfidence}
+              disabled={highConfidenceCount === 0}
+            >
+              Select high confidence ({highConfidenceCount})
+            </Button>
+            {selectedMatchIds.length > 0 && (
+              <Button size="small" onClick={() => setSelectedMatchIds([])}>
+                Clear
+              </Button>
+            )}
+            <Box flex={1} />
+            <Button
+              variant="contained"
+              size="small"
+              startIcon={<ApproveAllIcon />}
+              onClick={handleBulkApprove}
+              disabled={approving || selectedMatchIds.length === 0}
+            >
+              {approving
+                ? 'Approving...'
+                : `Approve ${selectedMatchIds.length || ''} selected`}
+            </Button>
+          </Box>
+        )}
+
         {/* Transactions Table */}
         {loading ? (
           <Box display="flex" justifyContent="center" py={4}>
@@ -338,6 +536,7 @@ const Reconciliation = () => {
             <Table stickyHeader size="small">
               <TableHead>
                 <TableRow>
+                  <TableCell padding="checkbox" />
                   <TableCell>Date</TableCell>
                   <TableCell>Sender</TableCell>
                   <TableCell>Phone</TableCell>
@@ -345,13 +544,14 @@ const Reconciliation = () => {
                   <TableCell>Category</TableCell>
                   <TableCell>Status</TableCell>
                   <TableCell>Match</TableCell>
+                  <TableCell align="right">Confidence</TableCell>
                   <TableCell align="right">Actions</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
                 {filteredTransactions.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={8} align="center">
+                    <TableCell colSpan={10} align="center">
                       <Typography color="text.secondary" py={4}>
                         No transactions found
                       </Typography>
@@ -360,6 +560,19 @@ const Reconciliation = () => {
                 ) : (
                   filteredTransactions.map((tx) => (
                     <TableRow key={tx.id} hover>
+                      <TableCell padding="checkbox">
+                        {tx.reconciliationMatch?.status === 'PENDING' && (
+                          <Checkbox
+                            size="small"
+                            checked={selectedMatchIds.includes(
+                              tx.reconciliationMatch.id,
+                            )}
+                            onChange={() =>
+                              toggleMatchSelection(tx.reconciliationMatch!.id)
+                            }
+                          />
+                        )}
+                      </TableCell>
                       <TableCell>
                         {new Date(tx.transactionDate).toLocaleDateString()}
                       </TableCell>
@@ -398,7 +611,26 @@ const Reconciliation = () => {
                         )}
                       </TableCell>
                       <TableCell align="right">
-                        {tx.status === 'PENDING' && (
+                        {tx.reconciliationMatch?.confidenceScore != null ? (
+                          <Chip
+                            label={`${Math.round(
+                              tx.reconciliationMatch.confidenceScore,
+                            )}%`}
+                            size="small"
+                            color={
+                              tx.reconciliationMatch.confidenceScore >=
+                              HIGH_CONFIDENCE
+                                ? 'success'
+                                : 'default'
+                            }
+                            variant="outlined"
+                          />
+                        ) : (
+                          '-'
+                        )}
+                      </TableCell>
+                      <TableCell align="right">
+                        {tx.status === 'PENDING' && !tx.reconciliationMatch && (
                           <Tooltip title="Match to contact">
                             <IconButton
                               size="small"
@@ -408,8 +640,14 @@ const Reconciliation = () => {
                             </IconButton>
                           </Tooltip>
                         )}
-                        {tx.status === 'RECONCILED' &&
-                          tx.reconciliationMatch?.status === 'PENDING' && (
+                        {/*
+                          A pending match is what awaits approval. This used to
+                          also require tx.status === 'RECONCILED', which only
+                          becomes true once a match is approved — so these
+                          buttons could never appear and a matched transaction
+                          was stuck on PENDING forever.
+                        */}
+                        {tx.reconciliationMatch?.status === 'PENDING' && (
                             <>
                               <Tooltip title="Approve match">
                                 <IconButton

--- a/src/modules/finance/types.ts
+++ b/src/modules/finance/types.ts
@@ -129,8 +129,14 @@ export interface DistributionBatch {
   periodStart: string;
   periodEnd: string;
   status: BatchStatus;
-  /** Absent unless the endpoint loaded the relation — always guard it. */
+  /**
+   * Only populated by the batch-detail endpoint. The list endpoint omits it
+   * and returns `distributionCount` instead, so `undefined` here means "not
+   * loaded", never "none".
+   */
   distributions?: Distribution[];
+  /** Line count, returned by the list endpoint. */
+  distributionCount?: number;
   /** Postgres numeric arrives as a string; coerce before formatting. */
   totalAmount: number | string;
   createdBy?: {

--- a/src/modules/finance/types.ts
+++ b/src/modules/finance/types.ts
@@ -129,8 +129,10 @@ export interface DistributionBatch {
   periodStart: string;
   periodEnd: string;
   status: BatchStatus;
-  distributions: Distribution[];
-  totalAmount: number;
+  /** Absent unless the endpoint loaded the relation — always guard it. */
+  distributions?: Distribution[];
+  /** Postgres numeric arrives as a string; coerce before formatting. */
+  totalAmount: number | string;
   createdBy?: {
     id: number;
     name: string;
@@ -149,19 +151,16 @@ export interface Distribution {
   batchId: number;
   sourceMatchId?: number;
   category: TransactionCategory;
-  fromAccount?: FinancialAccount;
-  fromAccountId?: number;
-  toAccount?: FinancialAccount;
-  toAccountId?: number;
-  toLocation?: {
+  /** Where the money goes — an account or a group, per the server entity. */
+  targetAccount?: FinancialAccount;
+  targetGroup?: {
     id: number;
     name: string;
   };
-  toLocationId?: number;
-  amount: number;
-  percentage?: number;
-  purpose: string;
-  transferred: boolean;
+  amount: number | string;
+  percentage?: number | string;
+  /** Free-text purpose from the distribution rule. */
+  description?: string;
   transferredAt?: string;
   transferReference?: string;
   metadata?: Record<string, unknown>;
@@ -225,6 +224,8 @@ export interface ParsedTransaction {
   senderPhone?: string;
   narration?: string;
   category: TransactionCategory;
+  /** Why this row got its category: the rule that fired, or the default. */
+  matchedRule?: string;
   isValid: boolean;
   errors?: string[];
 }
@@ -238,12 +239,21 @@ export interface DistributionCalculationRequest {
 
 // Report types
 export interface ReconciliationSummary {
-  totalImported: number;
-  totalMatched: number;
-  totalPending: number;
-  totalDisputed: number;
+  totalTransactions: number;
+  totalAmount: number;
+  pendingCount: number;
+  pendingAmount: number;
+  reconciledCount: number;
+  reconciledAmount: number;
+  disputedCount: number;
+  disputedAmount: number;
+  /** Already a percentage (0-100), not a fraction. */
   matchRate: number;
-  byCategory: Record<TransactionCategory, number>;
+  byCategory: {
+    category: string;
+    count: number;
+    amount: number;
+  }[];
 }
 
 export interface DistributionSummary {


### PR DESCRIPTION
# Summary of changes
- Wires the finance module's four screens to the API. Every screen was built against endpoints that did not exist or had a different contract, so Import, Reconciliation, Financial Reports and Distributions were all non-functional.
- **Import (`ImportTransactions.tsx`)**: removes `.xls` from the file picker, since ExcelJS cannot read legacy binary workbooks in any mode; corrects `importResult.errors` from `number` to `string[]` (the server returns messages, so the old code rendered `, [object Array] errors`); adds a "Why" column to the preview showing which category rule matched each row. File validation is by extension only — browsers report CSV MIME types inconsistently (`text/csv`, `application/vnd.ms-excel`, or empty depending on the OS), and the server selects its reader by extension, so a MIME check added false rejections without adding safety.
- **Reconciliation (`Reconciliation.tsx`)**: points the manual match at the existing `POST /matches` instead of the non-existent `/match`; fixes the Approve/Reject buttons, which were gated on `tx.status === 'RECONCILED' && match.status === 'PENDING'` — mutually exclusive states, so they could never render and a matched transaction was stuck on Pending forever; adds **Run Auto-Match** and **Approve All High Confidence** bulk approval, both backed by endpoints that already existed and nothing called; adds a Confidence column.
- **Reconciliation bulk selection hygiene**: `selectedMatchIds` is cleared whenever the account, status or search filter changes, so a selection made against one account cannot be submitted from another view. `handleBulkApprove` additionally intersects the selection with the currently visible pending matches before submitting, and approving or rejecting a match individually removes it from the selection. Without these, ticking matches on account A, switching to account B and clicking approve would have approved the hidden account A matches.
- **Financial Reports (`FinancialReports.tsx`)**: repoints the summary from `/reconciliation/summary` to `/reports/summary`, renames the query params from `dateFrom`/`dateTo` to `startDate`/`endDate`, and adopts the server's response shape — the old field names (`totalImported`, `totalMatched`) would have thrown on `undefined.toLocaleString()` once the fetch succeeded. Also corrects `matchRate`, which was multiplied by 100 despite already being a percentage (would have rendered 5000%), and `byCategory`, which is an array rather than a `Record`.
- **Report card labels**: the summary cards read "Total Transactions" and "Reconciled", matching the metrics the endpoint actually returns (`totalTransactions`, `reconciledCount`). The previous "Total Imported" and "Matched" labels described different quantities.
- **Financial Reports export**: replaces `window.open` with the shared `downLoad` helper plus the blob-to-anchor save already used by `BulkUpload.tsx`, so the request carries the bearer token and gets the app's session-expiry handling. The button now reports success or failure instead of unconditionally claiming "Export started".
- **Distributions (`Distributions.tsx`)**: repoints batch listing to `/distributions/batches` (the bare route returns individual distributions), and submit/approve/execute to `POST /distributions/batches/{id}/…` (they were `PUT` on paths missing the `/batches` segment). Guards `batch.distributions` — it is absent unless the endpoint loads the relation, and MUI `Collapse` mounts children while closed, so `undefined.map()` blanked the entire page. Aligns the row fields with the server entity (`description`, `targetAccount`, `targetGroup`) and derives the per-line transferred state from the batch status, since no per-line flag exists.
- Adds a `money()` helper: Postgres `numeric` columns arrive as strings, so `"1500.00".toLocaleString()` rendered without separators and threw outright on null. The affected types are widened to `number | string` so this is visible rather than implied.
- **`constants.ts`**: adds the missing `financialReports` remote route.

# How should this be tested? [Screenshots, Video or Type instructions]
- Run against a server branch containing the paired server PR. **Clear Vite's dependency cache first** (`rm -rf node_modules/.vite && npm run dev`) and hard-reload — it survives a plain restart and will otherwise serve pre-change bundles.
- **Import**: Admin → Import Transactions. Confirm the picker accepts only `.csv` and `.xlsx`. Upload a CSV, check the preview lists every row with valid/invalid chips, per-row error text, and a "Why" column naming the matched rule (or "Default category"). Import and confirm the success message counts imported rows and failures separately.
- **Reconciliation**: pick a single account and click **Run Auto-Match**; confirm the toast reports how many of how many matched, and that rows gain a Confidence percentage. Confirm the button is disabled with an explanatory tooltip while the account filter is "All".
- **Bulk approve**: with pending matches present, confirm the action bar appears. Click **Select high confidence** and check it ticks only rows at 90% or above. Approve, and confirm those transactions move to Reconciled and drop out of the Pending filter.
- **Selection safety**: tick some pending matches on one account, switch the account filter, and confirm the selection clears rather than carrying over. Repeat with the status filter and the search box. Then tick a match, approve it individually via the row button, and confirm the bulk count decrements rather than leaving a stale id behind.
- **Manual match**: on a pending transaction click the link icon, confirm suggestions load with a confidence score and plain-English reasons — including a name-similarity percentage that reads as a sensible figure, not a four-digit one. Pick a contact and save. The row should show the matched contact and gain Approve/Reject buttons; it stays Pending until approved, which is the documented behaviour.
- **Reports**: set a date range and confirm the four summary cards populate, that their labels describe what they show, and that the match rate reads as a sensible percentage (not 5000%). Click **Export CSV** and confirm a file downloads through the normal request path — no new tab, and the button reads "Exporting..." while in flight.
- **Distributions**: confirm the page renders its batch list rather than a blank screen, that expanding a batch shows either its lines or "No distribution lines on this batch yet", and that Submit → Approve → Execute each advance the batch status.
- Checks: `npx tsc --noEmit -p tsconfig.app.json` is clean. `npx eslint` on the changed files shows no new problems — each retains only its pre-existing `no-explicit-any` / `react-hooks/exhaustive-deps` finding.

# Notes for reviewers
- This PR requires the paired **server** PR. Merged alone, most screens still fail — the endpoints do not exist on `develop`.
- The Reconciliation Approve/Reject fix is the highest-value change to review: the old condition was unsatisfiable, which is why matched transactions appeared stuck. It is now keyed on the match's own status.
- Selection clearing is deliberately handled in three places rather than one: filter changes clear it, individual approve/reject removes the affected id, and the submit path intersects with what is on screen. The last is defensive — it makes it impossible to POST a match id the user cannot currently see, regardless of how the selection reached that state.
- The Distributions blank page was a render crash, not a data problem. The guard is still needed even though the server now loads the relation: `Collapse` mounts children while closed, so any batch arriving without it would crash the whole route.
- Amount formatting deliberately coerces with `Number(...)`. A value rendering as `NaN` indicates the API sent something unexpected rather than a formatting bug.
- `ReconciliationSummary`, `Distribution` and `DistributionBatch` in `types.ts` were describing shapes the server never sent. They now match the API, so anything reading the old field names fails to compile. That is intended.
- No new dependencies. `del`, `downLoad`, `post` and `toast` were all already in use.

# Out of scope
- Contact creation from inside the manual match dialog ("+ Create New Contact" in the tutorial). The dialog matches to existing contacts only.
- Editing a contact's payment methods from the match dialog.
- Pagination or virtualisation on the reconciliation table; it renders whatever the API returns.
- Any redesign of these screens — changes are confined to making the existing UI work.
- Fixing the pre-existing `no-explicit-any` and `react-hooks/exhaustive-deps` findings in the touched files; counts are unchanged.
- Cleaning up the transaction rows whose fields are shifted one column, imported before column detection existed. That is data remediation, not code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added financial reports with transaction totals, reconciliation status, pending items, and authenticated CSV export progress.
  - Added automatic matching, confidence scores, selectable matches, and bulk approval for reconciliation.
  - Added matched-rule details and per-row import error messages.
  - Added expanded distribution details with destination, descriptions, percentages, amounts, and execution progress.

- **Bug Fixes**
  - Improved financial amount and percentage formatting.
  - Corrected distribution actions and reconciliation approval behavior.
  - File imports now consistently support CSV and XLSX extensions.
  - Added clearer feedback while financial reports, distributions, and imports are processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->